### PR TITLE
#6526 Add a null check for validation person address

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
@@ -1,6 +1,6 @@
-/*******************************************************************************
+/*
  * SORMAS® - Surveillance Outbreak Response Management & Analysis System
- * Copyright © 2016-2018 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
+ * Copyright © 2016-2021 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
- *******************************************************************************/
+ */
 package de.symeda.sormas.backend.person;
 
 import static java.util.Comparator.comparing;
@@ -542,15 +542,16 @@ public class PersonFacadeEjb implements PersonFacade {
 					.getValidationError(Validations.validPhoneNumber, I18nProperties.getPrefixCaption(PersonDto.I18N_PREFIX, PersonDto.PHONE)));
 		}
 		if (source.getAddress() != null) {
-
 			if (source.getAddress().getRegion() != null
-					&& source.getAddress().getDistrict() != null
-					&& !districtFacade.getDistrictByUuid(source.getAddress().getDistrict().getUuid()).getRegion().equals(source.getAddress().getRegion())) {
+				&& source.getAddress().getDistrict() != null
+				&& !districtFacade.getDistrictByUuid(source.getAddress().getDistrict().getUuid())
+					.getRegion()
+					.equals(source.getAddress().getRegion())) {
 				throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.noAddressDistrictInAddressRegion));
 			}
 			if (source.getAddress().getDistrict() != null
-					&& source.getAddress().getCommunity() != null
-					&& !communityFacade.getByUuid(source.getAddress().getCommunity().getUuid()).getDistrict().equals(source.getAddress().getDistrict())) {
+				&& source.getAddress().getCommunity() != null
+				&& !communityFacade.getByUuid(source.getAddress().getCommunity().getUuid()).getDistrict().equals(source.getAddress().getDistrict())) {
 				throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.noAddressCommunityInAddressDistrict));
 			}
 			if ((source.getAddress().getDistrict() != null || source.getAddress().getFacility() != null) && source.getAddress().getRegion() == null) {
@@ -560,13 +561,13 @@ public class PersonFacadeEjb implements PersonFacade {
 				FacilityDto healthFacility = facilityFacade.getByUuid(source.getAddress().getFacility().getUuid());
 
 				if (source.getAddress().getCommunity() == null
-						&& healthFacility.getDistrict() != null
-						&& !healthFacility.getDistrict().equals(source.getAddress().getDistrict())) {
+					&& healthFacility.getDistrict() != null
+					&& !healthFacility.getDistrict().equals(source.getAddress().getDistrict())) {
 					throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.noAddressFacilityInAddressDistrict));
 				}
 				if (source.getAddress().getCommunity() != null
-						&& healthFacility.getCommunity() != null
-						&& !source.getAddress().getCommunity().equals(healthFacility.getCommunity())) {
+					&& healthFacility.getCommunity() != null
+					&& !source.getAddress().getCommunity().equals(healthFacility.getCommunity())) {
 					throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.noAddressFacilityInAddressCommunity));
 				}
 				if (healthFacility.getRegion() != null && !source.getAddress().getRegion().equals(healthFacility.getRegion())) {
@@ -574,25 +575,25 @@ public class PersonFacadeEjb implements PersonFacade {
 				}
 			}
 			if (!StringUtils.isAllBlank(
-					source.getAddress().getContactPersonFirstName(),
-					source.getAddress().getContactPersonLastName(),
-					source.getAddress().getContactPersonEmail(),
-					source.getAddress().getContactPersonPhone()) && source.getAddress().getFacilityType() == null) {
+				source.getAddress().getContactPersonFirstName(),
+				source.getAddress().getContactPersonLastName(),
+				source.getAddress().getContactPersonEmail(),
+				source.getAddress().getContactPersonPhone()) && source.getAddress().getFacilityType() == null) {
 				throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.importPersonContactDetailsWithoutFacilityType));
 			}
 			if (StringUtils.isNotBlank(source.getAddress().getContactPersonEmail())
-					&& !source.getAddress().getContactPersonEmail().matches(DataHelper.getEmailValidationRegex())) {
+				&& !source.getAddress().getContactPersonEmail().matches(DataHelper.getEmailValidationRegex())) {
 				throw new ValidationRuntimeException(
-						I18nProperties.getValidationError(
-								Validations.validEmailAddress,
-								I18nProperties.getPrefixCaption(LocationDto.I18N_PREFIX, LocationDto.CONTACT_PERSON_EMAIL)));
+					I18nProperties.getValidationError(
+						Validations.validEmailAddress,
+						I18nProperties.getPrefixCaption(LocationDto.I18N_PREFIX, LocationDto.CONTACT_PERSON_EMAIL)));
 			}
 			if (StringUtils.isNotBlank(source.getAddress().getContactPersonPhone())
-					&& source.getAddress().getContactPersonPhone().matches(DataHelper.getPhoneNumberValidationRegex())) {
+				&& source.getAddress().getContactPersonPhone().matches(DataHelper.getPhoneNumberValidationRegex())) {
 				throw new ValidationRuntimeException(
-						I18nProperties.getValidationError(
-								Validations.validPhoneNumber,
-								I18nProperties.getPrefixCaption(LocationDto.I18N_PREFIX, LocationDto.CONTACT_PERSON_PHONE)));
+					I18nProperties.getValidationError(
+						Validations.validPhoneNumber,
+						I18nProperties.getPrefixCaption(LocationDto.I18N_PREFIX, LocationDto.CONTACT_PERSON_PHONE)));
 			}
 		}
 


### PR DESCRIPTION
At the moment the performance tests are causing a lot of NPE due to checks introduced with #6422 which don't account for the person not having an address

Basically it's just a `if (source.getAddress() != null)` which surrounds all the address checks.

Fixes #6526