### PR TITLE
#11963 compile dependencies to serverlibs

### DIFF
--- a/sormas-api/pom.xml
+++ b/sormas-api/pom.xml
@@ -21,42 +21,32 @@
 
 	<dependencies>
 
+		<!-- *** Payara modules *** -->
+
 		<dependency>
 			<groupId>javax</groupId>
 			<artifactId>javaee-web-api</artifactId>
 		</dependency>
 
+		<!-- *** Payara modules END *** -->
+
+		<!-- *** Domain libs *** -->
+
 		<dependency>
 			<groupId>com.opencsv</groupId>
 			<artifactId>opencsv</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context</artifactId>
 			<exclusions>
 				<exclusion>
-					<groupId>org.springframework</groupId>
-					<artifactId>spring-jcl</artifactId>
+					<groupId>commons-collections</groupId>
+					<artifactId>commons-collections</artifactId>
+					<!-- Prioritise to use commons-collections4 -->
 				</exclusion>
 			</exclusions>
 		</dependency>
 
 		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<scope>provided</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.poi</groupId>
-			<artifactId>poi-ooxml</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.glassfish.jersey.media</groupId>
-			<artifactId>jersey-media-json-jackson</artifactId>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
 		</dependency>
 
 		<dependency>
@@ -65,45 +55,63 @@
 		</dependency>
 
 		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-collections4</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.glassfish.jersey.media</groupId>
+			<artifactId>jersey-media-json-jackson</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.jsoup</groupId>
 			<artifactId>jsoup</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcpkix-jdk15on</artifactId>
-			<scope>compile</scope>
-		</dependency>
+		<!-- *** Domain libs END *** -->
 
-		<dependency>
-			<groupId>com.tngtech.archunit</groupId>
-			<artifactId>archunit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.tngtech.archunit</groupId>
-			<artifactId>archunit-junit5</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>uk.co.jemos.podam</groupId>
-			<artifactId>podam</artifactId>
-		</dependency>
+		<!-- *** Test dependencies *** -->
 
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
 			<scope>test</scope>
 		</dependency>
+
 		<dependency>
-			<groupId>io.swagger.core.v3</groupId>
-			<artifactId>swagger-jaxrs2</artifactId>
+			<groupId>com.tngtech.archunit</groupId>
+			<artifactId>archunit</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.tngtech.archunit</groupId>
+			<artifactId>archunit-junit5</artifactId>
 		</dependency>
 
 		<dependency>
-			<groupId>io.swagger.core.v3</groupId>
-			<artifactId>swagger-jaxrs2-servlet-initializer-v2</artifactId>
+			<groupId>uk.co.jemos.podam</groupId>
+			<artifactId>podam</artifactId>
 		</dependency>
+
+		<!-- *** Test dependencies END *** -->
+
 	</dependencies>
 
 </project>

--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/classification/ClassificationExposureCriteriaDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/classification/ClassificationExposureCriteriaDto.java
@@ -20,7 +20,7 @@ import java.lang.reflect.Method;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 
 import de.symeda.sormas.api.EntityDto;
 import de.symeda.sormas.api.caze.CaseDataDto;

--- a/sormas-api/src/main/java/de/symeda/sormas/api/disease/DiseaseVariant.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/disease/DiseaseVariant.java
@@ -19,7 +19,7 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 
 import de.symeda.sormas.api.customizableenum.CustomizableEnum;
 

--- a/sormas-api/src/main/java/de/symeda/sormas/api/person/OccupationType.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/person/OccupationType.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 
 import de.symeda.sormas.api.customizableenum.CustomizableEnum;
 

--- a/sormas-api/src/main/java/de/symeda/sormas/api/utils/AgeGroupUtils.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/utils/AgeGroupUtils.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/sormas-api/src/main/java/de/symeda/sormas/api/utils/CsvStreamUtils.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/utils/CsvStreamUtils.java
@@ -28,8 +28,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Predicate;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Predicate;
 import org.apache.commons.lang3.StringUtils;
 
 import com.opencsv.CSVWriter;

--- a/sormas-app/app/build.gradle
+++ b/sormas-app/app/build.gradle
@@ -108,6 +108,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-perf'
     implementation 'com.google.firebase:firebase-config'
     implementation("de.symeda.sormas:sormas-api:$sormasVersion") { changing = true }
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
     implementation 'com.github.mpkorstanje:simmetrics-core:4.1.1'
     implementation 'com.google.guava:guava:31.1-jre'
     implementation 'com.opencsv:opencsv:5.7.1'
@@ -119,6 +120,10 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.apache.commons:commons-text:1.10.0'
     implementation 'org.jsoup:jsoup:1.15.4'
+    implementation('org.springframework:spring-context:5.3.27') {
+    	// spring-jcl duplicates commons-logging classes
+        exclude group: 'org.springframework', module: 'spring-jcl'
+    }
     implementation 'com.googlecode:openbeans:1.0'
     implementation files('libs/MPAndroidChart-v3.0.2.jar')
     implementation(name: 'CircleProgress-v1.2.1', ext: 'aar')

--- a/sormas-backend/pom.xml
+++ b/sormas-backend/pom.xml
@@ -14,19 +14,82 @@
 
 	<dependencies>
 
+		<!-- *** Payara modules *** -->
+
 		<dependency>
 			<groupId>javax</groupId>
 			<artifactId>javaee-api</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>javax.validation</groupId>
 			<artifactId>validation-api</artifactId>
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
+			<groupId>fish.payara.api</groupId>
+			<artifactId>payara-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>fish.payara.security.connectors</groupId>
+			<artifactId>security-connector-oidc-client</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.microprofile.config</groupId>
+			<artifactId>microprofile-config-api</artifactId>
+		</dependency>
+
+		<!-- *** Payara modules END *** -->
+
+		<!-- *** Domain libs *** -->
+
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-structures-r4</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>org.hl7.fhir.r4</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.http-client</groupId>
+			<artifactId>google-http-client</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.google.http-client</groupId>
+			<artifactId>google-http-client-gson</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.oauth-client</groupId>
+			<artifactId>google-oauth-client</artifactId>
+			<!-- OIDC for S2S -->
+		</dependency>
+
+		<dependency>
+			<groupId>com.googlecode.libphonenumber</groupId>
+			<artifactId>libphonenumber</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.ibm.etcd</groupId>
+			<artifactId>etcd-java</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.jayway.jsonpath</groupId>
+			<artifactId>json-path</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.nexmo</groupId>
+			<artifactId>client</artifactId>
 		</dependency>
 
 		<dependency>
@@ -35,9 +98,110 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.vladmihalcea</groupId>
+			<artifactId>hibernate-types-55</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-beanutils</groupId>
+			<artifactId>commons-beanutils</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>commons-validator</groupId>
 			<artifactId>commons-validator</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>fr.opensagres.xdocreport</groupId>
+			<artifactId>xdocreport</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>fr.opensagres.xdocreport</groupId>
+			<artifactId>fr.opensagres.xdocreport.template.velocity</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-collections4</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.poi</groupId>
+			<artifactId>poi-ooxml</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.tika</groupId>
+			<artifactId>tika-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tika</groupId>
+			<artifactId>tika-parsers-standard-package</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bcpkix-jdk15on</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.docx4j</groupId>
+			<artifactId>docx4j-docx-anon</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.docx4j</groupId>
+			<artifactId>docx4j-JAXB-ReferenceImpl</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-ehcache</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jsoup</groupId>
+			<artifactId>jsoup</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-admin-client</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.reflections</groupId>
+			<artifactId>reflections</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+
+		<!-- *** Domain libs END *** -->
+
+		<!-- *** Compile dependencies *** -->
 
 		<dependency>
 			<groupId>${project.groupId}</groupId>
@@ -50,69 +214,20 @@
 			<artifactId>gt-shapefile</artifactId>
 		</dependency>
 
+		<!-- *** Compile dependencies END *** -->
+
+		<!-- *** Test dependencies *** -->
+
 		<dependency>
-			<groupId>com.nexmo</groupId>
-			<artifactId>client</artifactId>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<scope>test</scope>
+			<!-- Avoids java.util.MissingResourceException: Can't find bundle for base name javax.servlet.LocalStrings, locale de_DE -->
 		</dependency>
 
 		<dependency>
-			<groupId>org.jsoup</groupId>
-			<artifactId>jsoup</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.poi</groupId>
-			<artifactId>poi-ooxml</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>fr.opensagres.xdocreport</groupId>
-			<artifactId>xdocreport</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>fr.opensagres.xdocreport</groupId>
-			<artifactId>fr.opensagres.xdocreport.template.velocity</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.docx4j</groupId>
-			<artifactId>docx4j-docx-anon</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.docx4j</groupId>
-			<artifactId>docx4j-JAXB-ReferenceImpl</artifactId>
-		</dependency>
-
-		<!-- Testing -->
-
-		<dependency>
-			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-ehcache</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.hibernate.validator</groupId>
-			<artifactId>hibernate-validator</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.vladmihalcea</groupId>
-			<artifactId>hibernate-types-55</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.glassfish</groupId>
-			<artifactId>javax.el</artifactId>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8-standalone</artifactId>
 		</dependency>
 
 		<dependency>
@@ -121,8 +236,28 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.tngtech.archunit</groupId>
+			<artifactId>archunit</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.tngtech.archunit</groupId>
+			<artifactId>archunit-junit5</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>de.hilling.junit.cdi</groupId>
 			<artifactId>cdi-test-core</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.geronimo.config</groupId>
+			<artifactId>geronimo-config-impl</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.glassfish</groupId>
+			<artifactId>javax.el</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>
@@ -141,139 +276,26 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>postgresql</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>p6spy</groupId>
 			<artifactId>p6spy</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-		</dependency>
+		<!-- *** Test dependencies END *** -->
 
-		<dependency>
-			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcpkix-jdk15on</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.geronimo.config</groupId>
-			<artifactId>geronimo-config-impl</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.googlecode.libphonenumber</groupId>
-			<artifactId>libphonenumber</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.tngtech.archunit</groupId>
-			<artifactId>archunit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.tngtech.archunit</groupId>
-			<artifactId>archunit-junit5</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<!-- Keycloak -->
-		<dependency>
-			<groupId>org.keycloak</groupId>
-			<artifactId>keycloak-admin-client</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>fish.payara.api</groupId>
-			<artifactId>payara-api</artifactId>
-		</dependency>
-
-		<!-- OpenID -->
-		<dependency>
-			<groupId>fish.payara.security.connectors</groupId>
-			<artifactId>security-connector-oidc-client</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.eclipse.microprofile.config</groupId>
-			<artifactId>microprofile-config-api</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.jayway.jsonpath</groupId>
-			<artifactId>json-path</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8-standalone</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.ibm.etcd</groupId>
-			<artifactId>etcd-java</artifactId>
-		</dependency>
-
-		<!-- OIDC for S2S -->
-		<dependency>
-			<groupId>com.google.oauth-client</groupId>
-			<artifactId>google-oauth-client</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.google.http-client</groupId>
-			<artifactId>google-http-client</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.google.http-client</groupId>
-			<artifactId>google-http-client-gson</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>javax</groupId>
-			<artifactId>javaee-web-api</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.testcontainers</groupId>
-			<artifactId>postgresql</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.testcontainers</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-core</artifactId>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>ca.uhn.hapi.fhir</groupId>
-			<artifactId>org.hl7.fhir.r4</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>ca.uhn.hapi.fhir</groupId>
-			<artifactId>hapi-fhir-structures-r4</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.reflections</groupId>
-			<artifactId>reflections</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.tika</groupId>
-			<artifactId>tika-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.tika</groupId>
-			<artifactId>tika-parsers-standard-package</artifactId>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/sormas-backend/pom.xml
+++ b/sormas-backend/pom.xml
@@ -261,6 +261,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
+			<scope>test</scope>
+			<!-- Needed dependency for docx4j-JAXB-ReferenceImpl -->
+		</dependency>
+
+		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-client</artifactId>
 		</dependency>

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -260,6 +260,14 @@
 			</dependency>
 
 			<dependency>
+				<groupId>org.glassfish.jaxb</groupId>
+				<artifactId>jaxb-runtime</artifactId>
+				<version>${glassfish.jaxb.version}</version>
+				<scope>provided</scope>
+				<!-- Payara module: jaxb-osgi -->
+			</dependency>
+
+			<dependency>
 				<groupId>org.glassfish.jersey.containers.glassfish</groupId>
 				<artifactId>jersey-gf-ejb</artifactId>
 				<version>${jersey.version}</version>
@@ -435,6 +443,17 @@
 				<artifactId>json-path</artifactId>
 				<version>2.7.0</version>
 				<scope>provided</scope>
+				<exclusions>
+					<!-- Exclude Payara modules here -->
+					<exclusion>
+						<groupId>net.minidev</groupId>
+						<artifactId>json-smart</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.ow2.asm</groupId>
+						<artifactId>asm</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 
 			<dependency>
@@ -442,6 +461,13 @@
 				<artifactId>client</artifactId>
 				<version>5.6.0</version>
 				<scope>provided</scope>
+				<exclusions>
+					<!-- Exclude Payara modules here -->
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-databind</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 
 			<dependency>
@@ -513,6 +539,37 @@
 				<artifactId>swagger-jaxrs2</artifactId>
 				<version>${swagger.version}</version>
 				<scope>provided</scope>
+				<exclusions>
+					<!-- Exclude Payara modules here -->
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-annotations</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-databind</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.fasterxml.jackson.dataformat</groupId>
+						<artifactId>jackson-dataformat-yaml</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>jakarta.validation</groupId>
+						<artifactId>jakarta.validation-api</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>jakarta.xml.bind</groupId>
+						<artifactId>jakarta.xml.bind-api</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.javassist</groupId>
+						<artifactId>javassist</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.yaml</groupId>
+						<artifactId>snakeyaml</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>io.swagger.core.v3</groupId>
@@ -582,6 +639,24 @@
 						<groupId>xml-apis</groupId>
 						<artifactId>xml-apis</artifactId>
 					</exclusion>
+					<!-- Exclude Payara modules here -->
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-core</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-databind</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.glassfish.jaxb</groupId>
+						<artifactId>jaxb-runtime</artifactId>
+						<!-- Payara module: jaxb-osgi -->
+					</exclusion>
+					<exclusion>
+						<groupId>org.ow2.asm</groupId>
+						<artifactId>asm</artifactId>
+					</exclusion>
 				</exclusions>
 			</dependency>
 
@@ -635,6 +710,14 @@
 				<artifactId>docx4j-JAXB-ReferenceImpl</artifactId>
 				<version>${docx4j.version}</version>
 				<scope>provided</scope>
+				<exclusions>
+					<!-- Exclude Payara modules here -->
+					<exclusion>
+						<groupId>org.glassfish.jaxb</groupId>
+						<artifactId>jaxb-runtime</artifactId>
+						<!-- Payara module: jaxb-osgi -->
+					</exclusion>
+				</exclusions>
 			</dependency>
 
 			<dependency>
@@ -644,6 +727,10 @@
 				<scope>provided</scope>
 				<exclusions>
 					<!-- Exclude Payara modules here -->
+					<exclusion>
+						<groupId>com.fasterxml</groupId>
+						<artifactId>classmate</artifactId>
+					</exclusion>
 					<exclusion>
 						<groupId>com.sun.istack</groupId>
 						<artifactId>istack-commons-runtime</artifactId>
@@ -664,6 +751,16 @@
 						<!-- Payara module: jakarta.xml.bind-api -->
 					</exclusion>
 					<exclusion>
+						<groupId>org.glassfish.jaxb</groupId>
+						<artifactId>jaxb-runtime</artifactId>
+						<!-- Payara module: jaxb-osgi -->
+					</exclusion>
+					<exclusion>
+						<groupId>org.glassfish.jaxb</groupId>
+						<artifactId>txw2</artifactId>
+						<!-- Payara module: jaxb-osgi -->
+					</exclusion>
+					<exclusion>
 						<groupId>org.javassist</groupId>
 						<artifactId>javassist</artifactId>
 					</exclusion>
@@ -680,20 +777,6 @@
 				<version>1.2.18</version>
 				<scope>provided</scope>
 				<!-- Dependency of hibernate-core - optional for jaxb-runtime and currently excluded -->
-			</dependency>
-			<dependency>
-				<groupId>org.glassfish.jaxb</groupId>
-				<artifactId>jaxb-runtime</artifactId>
-				<version>${glassfish.jaxb.version}</version>
-				<scope>provided</scope>
-				<!-- Dependency of hibernate-core - provided as payara module jaxb-osgi -->
-			</dependency>
-			<dependency>
-				<groupId>org.glassfish.jaxb</groupId>
-				<artifactId>txw2</artifactId>
-				<version>${glassfish.jaxb.version}</version>
-				<scope>provided</scope>
-				<!-- Dependency of hibernate-core - provided as payara module jaxb-osgi -->
 			</dependency>
 			<dependency>
 				<groupId>org.jvnet.staxex</groupId>
@@ -715,6 +798,7 @@
 				<scope>provided</scope>
 				<!-- Additional datatypes for hibernate-core -->
 				<exclusions>
+					<!-- Exclude Payara modules here -->
 					<exclusion>
 						<groupId>com.fasterxml.jackson.module</groupId>
 						<artifactId>jackson-module-jaxb-annotations</artifactId>
@@ -728,6 +812,15 @@
 				<version>${resteasy.version}</version>
 				<scope>provided</scope>
 				<exclusions>
+					<!-- Exclude Payara modules here -->
+					<exclusion>
+						<groupId>jakarta.activation</groupId>
+						<artifactId>jakarta.activation-api</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>jakarta.validation</groupId>
+						<artifactId>jakarta.validation-api</artifactId>
+					</exclusion>
 					<exclusion>
 						<groupId>org.jboss.spec.javax.annotation</groupId>
 						<artifactId>jboss-annotations-api_1.3_spec</artifactId>
@@ -743,6 +836,10 @@
 						<artifactId>jboss-jaxb-api_2.3_spec</artifactId>
 						<!-- Payara module: jakarta.xml.bind-api -->
 					</exclusion>
+					<exclusion>
+						<groupId>org.ow2.asm</groupId>
+						<artifactId>asm</artifactId>
+					</exclusion>
 				</exclusions>
 			</dependency>
 			<dependency>
@@ -750,6 +847,21 @@
 				<artifactId>resteasy-jackson2-provider</artifactId>
 				<version>${resteasy.version}</version>
 				<scope>provided</scope>
+				<exclusions>
+					<!-- Exclude Payara modules here -->
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-annotations</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-core</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-databind</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.jboss.resteasy</groupId>
@@ -757,6 +869,12 @@
 				<version>${resteasy.version}</version>
 				<scope>provided</scope>
 				<exclusions>
+					<!-- Exclude Payara modules here -->
+					<exclusion>
+						<groupId>org.glassfish.jaxb</groupId>
+						<artifactId>jaxb-runtime</artifactId>
+						<!-- Payara module: jaxb-osgi -->
+					</exclusion>
 					<exclusion>
 						<groupId>org.jboss.spec.javax.xml.bind</groupId>
 						<artifactId>jboss-jaxb-api_2.3_spec</artifactId>
@@ -770,6 +888,11 @@
 				<version>${resteasy.version}</version>
 				<scope>provided</scope>
 				<exclusions>
+					<!-- Exclude Payara modules here -->
+					<exclusion>
+						<groupId>com.sun.mail</groupId>
+						<artifactId>jakarta.mail</artifactId>
+					</exclusion>
 					<exclusion>
 						<groupId>org.jboss.spec.javax.xml.bind</groupId>
 						<artifactId>jboss-jaxb-api_2.3_spec</artifactId>
@@ -849,6 +972,17 @@
 				<artifactId>keycloak-core</artifactId>
 				<version>${keycloak.version}</version>
 				<scope>provided</scope>
+				<exclusions>
+					<!-- Exclude Payara modules here -->
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-core</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-databind</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.keycloak</groupId>
@@ -867,6 +1001,21 @@
 				<artifactId>keycloak-servlet-filter-adapter</artifactId>
 				<version>${keycloak.version}</version>
 				<scope>provided</scope>
+				<exclusions>
+					<!-- Exclude Payara modules here -->
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-annotations</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-core</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-databind</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 
 			<dependency>
@@ -894,6 +1043,13 @@
 				<artifactId>reflections</artifactId>
 				<version>0.10.2</version>
 				<scope>provided</scope>
+				<exclusions>
+					<!-- Exclude Payara modules here -->
+					<exclusion>
+						<groupId>org.javassist</groupId>
+						<artifactId>javassist</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 
 			<!-- manual dependency
@@ -934,6 +1090,11 @@
 						<groupId>org.springframework</groupId>
 						<artifactId>spring-beans</artifactId>
 					</exclusion>
+					<exclusion>
+						<groupId>org.springframework</groupId>
+						<artifactId>spring-jcl</artifactId>
+						<!-- spring-jcl duplicates commons-logging classes -->
+					</exclusion>
 				</exclusions>
 			</dependency>
 
@@ -942,6 +1103,21 @@
 				<artifactId>hapi-fhir-structures-r4</artifactId>
 				<version>6.2.2</version>
 				<scope>provided</scope>
+				<exclusions>
+					<!-- Exclude Payara modules here -->
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-annotations</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-core</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-databind</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>ca.uhn.hapi.fhir</groupId>

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -631,10 +631,6 @@
 						<groupId>org.springframework</groupId>
 						<artifactId>spring-beans</artifactId>
 					</exclusion>
-					<exclusion>
-						<groupId>org.springframework</groupId>
-						<artifactId>spring-jcl</artifactId>
-					</exclusion>
 				</exclusions>
 			</dependency>
 

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -35,7 +35,8 @@
 		<swagger.version>2.2.8</swagger.version>
 		<bouncycastle.version>1.70</bouncycastle.version>
 		<keycloak.version>21.0.1</keycloak.version>
-		<resteasy.version>3.15.3.Final</resteasy.version>
+		<resteasy.version>4.7.7.Final</resteasy.version>
+		<kotlin-stdlib.version>1.6.20</kotlin-stdlib.version>
 		<xdocreport.version>2.0.4</xdocreport.version>
 		<docx4j.version>8.3.8</docx4j.version>
 		<archunit.version>1.0.1</archunit.version>
@@ -332,13 +333,13 @@
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-core</artifactId>
 				<version>${logback.version}</version>
-				<scope>runtime</scope>
+				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-classic</artifactId>
 				<version>${logback.version}</version>
-				<scope>runtime</scope>
+				<scope>provided</scope>
 			</dependency>
 
 			<dependency>
@@ -381,9 +382,65 @@
 			</dependency>
 
 			<dependency>
+				<groupId>com.google.code.gson</groupId>
+				<artifactId>gson</artifactId>
+				<version>2.10.1</version>
+				<scope>provided</scope>
+				<!-- Version defined to resolve version conflict between multiple usages -->
+			</dependency>
+
+			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
 				<version>31.1-jre</version>
+				<scope>provided</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>com.google.http-client</groupId>
+				<artifactId>google-http-client</artifactId>
+				<version>1.42.3</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.google.http-client</groupId>
+				<artifactId>google-http-client-gson</artifactId>
+				<version>1.42.3</version>
+				<scope>provided</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>com.google.oauth-client</groupId>
+				<artifactId>google-oauth-client</artifactId>
+				<version>1.34.1</version>
+				<scope>provided</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>com.googlecode.libphonenumber</groupId>
+				<artifactId>libphonenumber</artifactId>
+				<version>8.13.3</version>
+				<scope>provided</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>com.ibm.etcd</groupId>
+				<artifactId>etcd-java</artifactId>
+				<version>0.0.22</version>
+				<scope>provided</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>com.jayway.jsonpath</groupId>
+				<artifactId>json-path</artifactId>
+				<version>2.7.0</version>
+				<scope>provided</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>com.nexmo</groupId>
+				<artifactId>client</artifactId>
+				<version>5.6.0</version>
 				<scope>provided</scope>
 			</dependency>
 
@@ -429,6 +486,25 @@
 				<groupId>commons-logging</groupId>
 				<artifactId>commons-logging</artifactId>
 				<version>1.2</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>commons-validator</groupId>
+				<artifactId>commons-validator</artifactId>
+				<version>1.7</version>
+				<scope>provided</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>fr.opensagres.xdocreport</groupId>
+				<artifactId>xdocreport</artifactId>
+				<version>${xdocreport.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>fr.opensagres.xdocreport</groupId>
+				<artifactId>fr.opensagres.xdocreport.template.velocity</artifactId>
+				<version>${xdocreport.version}</version>
 				<scope>provided</scope>
 			</dependency>
 
@@ -484,14 +560,42 @@
 			</dependency>
 
 			<dependency>
+				<groupId>org.apache.poi</groupId>
+				<artifactId>poi-ooxml</artifactId>
+				<version>5.2.3</version>
+				<scope>provided</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.tika</groupId>
+				<artifactId>tika-core</artifactId>
+				<version>${apache-tika.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.tika</groupId>
+				<artifactId>tika-parsers-standard-package</artifactId>
+				<version>${apache-tika.version}</version>
+				<scope>provided</scope>
+				<exclusions>
+					<exclusion>
+						<groupId>xml-apis</groupId>
+						<artifactId>xml-apis</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+
+			<dependency>
 				<groupId>org.apache.xmlgraphics</groupId>
 				<artifactId>fop-events</artifactId>
 				<version>2.8</version>
+				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.xmlgraphics</groupId>
 				<artifactId>xmlgraphics-commons</artifactId>
 				<version>2.8</version>
+				<scope>provided</scope>
 			</dependency>
 
 			<dependency>
@@ -517,6 +621,20 @@
 				<groupId>org.checkerframework</groupId>
 				<artifactId>checker-qual</artifactId>
 				<version>3.29.0</version>
+				<scope>provided</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.docx4j</groupId>
+				<artifactId>docx4j-docx-anon</artifactId>
+				<version>${docx4j.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.docx4j</groupId>
+				<artifactId>docx4j-JAXB-ReferenceImpl</artifactId>
+				<version>${docx4j.version}</version>
+				<scope>provided</scope>
 			</dependency>
 
 			<dependency>
@@ -605,12 +723,104 @@
 			</dependency>
 
 			<dependency>
+				<groupId>org.jboss.resteasy</groupId>
+				<artifactId>resteasy-client</artifactId>
+				<version>${resteasy.version}</version>
+				<scope>provided</scope>
+				<exclusions>
+					<exclusion>
+						<groupId>org.jboss.spec.javax.annotation</groupId>
+						<artifactId>jboss-annotations-api_1.3_spec</artifactId>
+						<!-- Payara module: jakarta.annotation-api -->
+					</exclusion>
+					<exclusion>
+						<groupId>org.jboss.spec.javax.ws.rs</groupId>
+						<artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+						<!-- Payara module: jakarta.ws.rs-api -->
+					</exclusion>
+					<exclusion>
+						<groupId>org.jboss.spec.javax.xml.bind</groupId>
+						<artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+						<!-- Payara module: jakarta.xml.bind-api -->
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>org.jboss.resteasy</groupId>
+				<artifactId>resteasy-jackson2-provider</artifactId>
+				<version>${resteasy.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.jboss.resteasy</groupId>
+				<artifactId>resteasy-jaxb-provider</artifactId>
+				<version>${resteasy.version}</version>
+				<scope>provided</scope>
+				<exclusions>
+					<exclusion>
+						<groupId>org.jboss.spec.javax.xml.bind</groupId>
+						<artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+						<!-- Payara module: jakarta.xml.bind-api -->
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>org.jboss.resteasy</groupId>
+				<artifactId>resteasy-multipart-provider</artifactId>
+				<version>${resteasy.version}</version>
+				<scope>provided</scope>
+				<exclusions>
+					<exclusion>
+						<groupId>org.jboss.spec.javax.xml.bind</groupId>
+						<artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+						<!-- Payara module: jakarta.xml.bind-api -->
+					</exclusion>
+				</exclusions>
+			</dependency>
+
+			<dependency>
+				<groupId>org.jetbrains</groupId>
+				<artifactId>annotations</artifactId>
+				<version>17.0.0</version>
+				<scope>provided</scope>
+				<!-- Version defined to resolve version conflict between multiple usages -->
+			</dependency>
+
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-stdlib</artifactId>
+				<version>${kotlin-stdlib.version}</version>
+				<scope>provided</scope>
+				<!-- Version defined to resolve version conflict between multiple usages -->
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-stdlib-common</artifactId>
+				<version>${kotlin-stdlib.version}</version>
+				<scope>provided</scope>
+				<!-- Version defined to resolve version conflict between multiple usages -->
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-stdlib-jdk7</artifactId>
+				<version>${kotlin-stdlib.version}</version>
+				<scope>provided</scope>
+				<!-- Version defined to resolve version conflict between multiple usages -->
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-stdlib-jdk8</artifactId>
+				<version>${kotlin-stdlib.version}</version>
+				<scope>provided</scope>
+				<!-- Version defined to resolve version conflict between multiple usages -->
+			</dependency>
+
+			<dependency>
 				<groupId>org.keycloak</groupId>
 				<artifactId>keycloak-admin-client</artifactId>
 				<version>${keycloak.version}</version>
 				<scope>provided</scope>
 				<exclusions>
-					<!-- Exclude Payara modules here -->
 					<exclusion>
 						<groupId>org.jboss.spec.javax.annotation</groupId>
 						<artifactId>jboss-annotations-api_1.3_spec</artifactId>
@@ -679,6 +889,13 @@
 				</exclusions>
 			</dependency>
 
+			<dependency>
+				<groupId>org.reflections</groupId>
+				<artifactId>reflections</artifactId>
+				<version>0.10.2</version>
+				<scope>provided</scope>
+			</dependency>
+
 			<!-- manual dependency
 			SQL function copied to sormas-backend/src/main/resources/sql/versioning_function.sql
 			https://github.com/nearform/temporal_tables/releases/tag/v0.4.2
@@ -724,119 +941,27 @@
 				<groupId>ca.uhn.hapi.fhir</groupId>
 				<artifactId>hapi-fhir-structures-r4</artifactId>
 				<version>6.2.2</version>
-				<scope>runtime</scope>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>ca.uhn.hapi.fhir</groupId>
+				<artifactId>org.hl7.fhir.r4</artifactId>
+				<version>5.6.88</version>
+				<scope>provided</scope>
 			</dependency>
 
 			<!-- *** Domain libs END *** -->
 
 			<!-- *** Compile dependencies *** -->
-			<dependency>
-				<groupId>ca.uhn.hapi.fhir</groupId>
-				<artifactId>org.hl7.fhir.r4</artifactId>
-				<version>5.6.88</version>
-				<scope>compile</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>com.googlecode.libphonenumber</groupId>
-				<artifactId>libphonenumber</artifactId>
-				<version>8.13.3</version>
-			</dependency>
-
-			<dependency>
-				<groupId>com.jayway.jsonpath</groupId>
-				<artifactId>json-path</artifactId>
-				<version>2.7.0</version>
-			</dependency>
-
-			<dependency>
-				<groupId>com.nexmo</groupId>
-				<artifactId>client</artifactId>
-				<version>5.6.0</version>
-			</dependency>
-
-			<dependency>
-				<groupId>commons-validator</groupId>
-				<artifactId>commons-validator</artifactId>
-				<version>1.7</version>
-			</dependency>
-
-			<dependency>
-				<groupId>fr.opensagres.xdocreport</groupId>
-				<artifactId>xdocreport</artifactId>
-				<version>${xdocreport.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>fr.opensagres.xdocreport</groupId>
-				<artifactId>fr.opensagres.xdocreport.template.velocity</artifactId>
-				<version>${xdocreport.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>io.swagger.core.v3</groupId>
-				<artifactId>swagger-jaxrs2</artifactId>
-				<version>${swagger.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.apache.tika</groupId>
-				<artifactId>tika-core</artifactId>
-				<version>${apache-tika.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.tika</groupId>
-				<artifactId>tika-parsers-standard-package</artifactId>
-				<version>${apache-tika.version}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>xml-apis</groupId>
-						<artifactId>xml-apis</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-
-			<dependency>
-				<groupId>org.docx4j</groupId>
-				<artifactId>docx4j-docx-anon</artifactId>
-				<version>${docx4j.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.docx4j</groupId>
-				<artifactId>docx4j-JAXB-ReferenceImpl</artifactId>
-				<version>${docx4j.version}</version>
-			</dependency>
 
 			<dependency>
 				<groupId>org.geotools</groupId>
 				<artifactId>gt-shapefile</artifactId>
 				<version>28.2</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.jboss.resteasy</groupId>
-				<artifactId>resteasy-client</artifactId>
-				<version>${resteasy.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.jboss.resteasy</groupId>
-				<artifactId>resteasy-multipart-provider</artifactId>
-				<version>${resteasy.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.jboss.resteasy</groupId>
-				<artifactId>resteasy-jackson2-provider</artifactId>
-				<version>${resteasy.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.jboss.resteasy</groupId>
-				<artifactId>resteasy-jaxb-provider</artifactId>
-				<version>${resteasy.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.reflections</groupId>
-				<artifactId>reflections</artifactId>
-				<version>0.10.2</version>
+				<!-- 
+				  Kept as compile dependency because Ant collect-serverlibs fails:
+				  sormas-base\build.xml:53: org.apache.maven.artifact.InvalidArtifactRTException: For artifact {org.osgi:org.osgi.annotation:null:jar}: The version cannot be empty.
+				-->
 			</dependency>
 
 			<!-- ** Vaadin ** -->
@@ -962,12 +1087,6 @@
 			</dependency>
 
 			<dependency>
-				<groupId>org.apache.poi</groupId>
-				<artifactId>poi-ooxml</artifactId>
-				<version>5.2.3</version>
-			</dependency>
-
-			<dependency>
 				<groupId>org.hamcrest</groupId>
 				<artifactId>hamcrest</artifactId>
 				<version>${hamcrest.version}</version>
@@ -1030,29 +1149,6 @@
 			</dependency>
 
 			<!-- *** Test dependencies END *** -->
-
-			<dependency>
-				<groupId>com.ibm.etcd</groupId>
-				<artifactId>etcd-java</artifactId>
-				<version>0.0.22</version>
-			</dependency>
-
-			<!-- OIDC for S2S -->
-			<dependency>
-				<groupId>com.google.oauth-client</groupId>
-				<artifactId>google-oauth-client</artifactId>
-				<version>1.34.1</version>
-			</dependency>
-			<dependency>
-				<groupId>com.google.http-client</groupId>
-				<artifactId>google-http-client</artifactId>
-				<version>1.42.3</version>
-			</dependency>
-			<dependency>
-				<groupId>com.google.http-client</groupId>
-				<artifactId>google-http-client-gson</artifactId>
-				<version>1.42.3</version>
-			</dependency>
 
 		</dependencies>
 	</dependencyManagement>

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -35,7 +35,7 @@
 		<swagger.version>2.2.8</swagger.version>
 		<bouncycastle.version>1.70</bouncycastle.version>
 		<keycloak.version>21.0.1</keycloak.version>
-		<resteasy.version>4.7.7.Final</resteasy.version>
+		<resteasy.version>5.0.7.Final</resteasy.version>
 		<kotlin-stdlib.version>1.6.20</kotlin-stdlib.version>
 		<xdocreport.version>2.0.4</xdocreport.version>
 		<docx4j.version>8.3.8</docx4j.version>

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -445,10 +445,7 @@
 				<scope>provided</scope>
 				<exclusions>
 					<!-- Exclude Payara modules here -->
-					<exclusion>
-						<groupId>net.minidev</groupId>
-						<artifactId>json-smart</artifactId>
-					</exclusion>
+					<!-- net.minidev:json-smart is a Payara module, but for unknown reason can't be loaded by the json-path domain lib -->
 					<exclusion>
 						<groupId>org.ow2.asm</groupId>
 						<artifactId>asm</artifactId>

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -246,14 +246,40 @@
 			</dependency>
 
 			<dependency>
-				<groupId>org.glassfish.jersey.containers</groupId>
-				<artifactId>jersey-container-servlet</artifactId>
+				<groupId>org.glassfish.hk2</groupId>
+				<artifactId>osgi-resource-locator</artifactId>
+				<version>1.0.3</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.glassfish.hk2.external</groupId>
+				<artifactId>jakarta.inject</artifactId>
+				<version>2.6.1</version>
+				<scope>provided</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.glassfish.jersey.containers.glassfish</groupId>
+				<artifactId>jersey-gf-ejb</artifactId>
+				<version>${jersey.version}</version>
+				<scope>provided</scope>
+				<!-- Do not remove: Necessary to debug underlying logic of how ExceptionMappers are resolved in the IDE.-->
+			</dependency>
+			<dependency>
+				<groupId>org.glassfish.jersey.core</groupId>
+				<artifactId>jersey-client</artifactId>
 				<version>${jersey.version}</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.glassfish.jersey.core</groupId>
-				<artifactId>jersey-client</artifactId>
+				<artifactId>jersey-common</artifactId>
+				<version>${jersey.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.glassfish.jersey.core</groupId>
+				<artifactId>jersey-server</artifactId>
 				<version>${jersey.version}</version>
 				<scope>provided</scope>
 			</dependency>
@@ -268,14 +294,6 @@
 				<artifactId>jersey-media-json-jackson</artifactId>
 				<version>${jersey.version}</version>
 				<scope>provided</scope>
-			</dependency>
-
-			<!-- Do not remove: Necessary to debug underlying logic of how ExceptionMappers are resolved in the IDE.-->
-			<dependency>
-				<groupId>org.glassfish.jersey.containers.glassfish</groupId>
-				<artifactId>jersey-gf-ejb</artifactId>
-				<version>${jersey.version}</version>
-				<scope>compile</scope>
 			</dependency>
 
 			<dependency>
@@ -411,6 +429,19 @@
 				<groupId>commons-logging</groupId>
 				<artifactId>commons-logging</artifactId>
 				<version>1.2</version>
+				<scope>provided</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>io.swagger.core.v3</groupId>
+				<artifactId>swagger-jaxrs2</artifactId>
+				<version>${swagger.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>io.swagger.core.v3</groupId>
+				<artifactId>swagger-jaxrs2-servlet-initializer-v2</artifactId>
+				<version>${swagger.version}</version>
 				<scope>provided</scope>
 			</dependency>
 
@@ -571,6 +602,61 @@
 						<artifactId>jackson-module-jaxb-annotations</artifactId>
 					</exclusion>
 				</exclusions>
+			</dependency>
+
+			<dependency>
+				<groupId>org.keycloak</groupId>
+				<artifactId>keycloak-admin-client</artifactId>
+				<version>${keycloak.version}</version>
+				<scope>provided</scope>
+				<exclusions>
+					<!-- Exclude Payara modules here -->
+					<exclusion>
+						<groupId>org.jboss.spec.javax.annotation</groupId>
+						<artifactId>jboss-annotations-api_1.3_spec</artifactId>
+						<!-- Payara module: jakarta.annotation-api -->
+					</exclusion>
+					<exclusion>
+						<groupId>org.jboss.spec.javax.ws.rs</groupId>
+						<artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+						<!-- Payara module: jakarta.ws.rs-api -->
+					</exclusion>
+					<exclusion>
+						<groupId>org.jboss.spec.javax.xml.bind</groupId>
+						<artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+						<!-- Payara module: jakarta.xml.bind-api -->
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>org.keycloak</groupId>
+				<artifactId>keycloak-common</artifactId>
+				<version>${keycloak.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.keycloak</groupId>
+				<artifactId>keycloak-core</artifactId>
+				<version>${keycloak.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.keycloak</groupId>
+				<artifactId>keycloak-server-spi</artifactId>
+				<version>${keycloak.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.keycloak</groupId>
+				<artifactId>keycloak-server-spi-private</artifactId>
+				<version>${keycloak.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.keycloak</groupId>
+				<artifactId>keycloak-servlet-filter-adapter</artifactId>
+				<version>${keycloak.version}</version>
+				<scope>provided</scope>
 			</dependency>
 
 			<dependency>
@@ -748,57 +834,6 @@
 			</dependency>
 
 			<dependency>
-				<groupId>org.keycloak</groupId>
-				<artifactId>keycloak-admin-client</artifactId>
-				<version>${keycloak.version}</version>
-				<exclusions>
-					<!-- Exclude Payara modules here -->
-					<exclusion>
-						<groupId>org.jboss.spec.javax.annotation</groupId>
-						<artifactId>jboss-annotations-api_1.3_spec</artifactId>
-						<!-- Payara module: jakarta.annotation-api -->
-					</exclusion>
-					<exclusion>
-						<groupId>org.jboss.spec.javax.ws.rs</groupId>
-						<artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-						<!-- Payara module: jakarta.ws.rs-api -->
-					</exclusion>
-					<exclusion>
-						<groupId>org.jboss.spec.javax.xml.bind</groupId>
-						<artifactId>jboss-jaxb-api_2.3_spec</artifactId>
-						<!-- Payara module: jakarta.xml.bind-api -->
-					</exclusion>
-				</exclusions>
-			</dependency>
-			<dependency>
-				<groupId>org.keycloak</groupId>
-				<artifactId>keycloak-common</artifactId>
-				<version>${keycloak.version}</version>
-				<!-- No Domain lib, because it ran with Ant into problem, see https://stackoverflow.com/questions/64857838/invalid-jdk-version-in-profile-compile-java8-release-flag-unbounded-range-9 -->
-			</dependency>
-			<dependency>
-				<groupId>org.keycloak</groupId>
-				<artifactId>keycloak-core</artifactId>
-				<version>${keycloak.version}</version>
-				<!-- No Domain lib, because it ran with Ant into problem, see https://stackoverflow.com/questions/64857838/invalid-jdk-version-in-profile-compile-java8-release-flag-unbounded-range-9 -->
-			</dependency>
-			<dependency>
-				<groupId>org.keycloak</groupId>
-				<artifactId>keycloak-server-spi</artifactId>
-				<version>${keycloak.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.keycloak</groupId>
-				<artifactId>keycloak-server-spi-private</artifactId>
-				<version>${keycloak.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.keycloak</groupId>
-				<artifactId>keycloak-servlet-filter-adapter</artifactId>
-				<version>${keycloak.version}</version>
-			</dependency>
-
-			<dependency>
 				<groupId>org.reflections</groupId>
 				<artifactId>reflections</artifactId>
 				<version>0.10.2</version>
@@ -958,12 +993,6 @@
 				<artifactId>hibernate-validator</artifactId>
 				<version>6.2.5.Final</version>
 				<scope>test</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>io.swagger.core.v3</groupId>
-				<artifactId>swagger-jaxrs2-servlet-initializer-v2</artifactId>
-				<version>${swagger.version}</version>
 			</dependency>
 
 			<dependency>

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -393,6 +393,7 @@
 				<groupId>commons-codec</groupId>
 				<artifactId>commons-codec</artifactId>
 				<version>1.15</version>
+				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>commons-collections</groupId>
@@ -615,6 +616,28 @@
 				<version>${slf4j.version}</version>
 				<scope>provided</scope>
 			</dependency>
+
+			<dependency>
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-context</artifactId>
+				<version>5.3.27</version>
+				<scope>provided</scope>
+				<exclusions>
+					<exclusion>
+						<groupId>org.springframework</groupId>
+						<artifactId>spring-aop</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.springframework</groupId>
+						<artifactId>spring-beans</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.springframework</groupId>
+						<artifactId>spring-jcl</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+
 			<dependency>
 				<groupId>ca.uhn.hapi.fhir</groupId>
 				<artifactId>hapi-fhir-structures-r4</artifactId>
@@ -945,22 +968,6 @@
 				<groupId>io.swagger.core.v3</groupId>
 				<artifactId>swagger-jaxrs2-servlet-initializer-v2</artifactId>
 				<version>${swagger.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.springframework</groupId>
-				<artifactId>spring-context</artifactId>
-				<version>5.3.27</version>
-				<exclusions>
-					<exclusion>
-						<groupId>org.springframework</groupId>
-						<artifactId>spring-aop</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>org.springframework</groupId>
-						<artifactId>spring-beans</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 
 			<dependency>

--- a/sormas-keycloak-service-provider/pom.xml
+++ b/sormas-keycloak-service-provider/pom.xml
@@ -11,31 +11,42 @@
 	<name>${project.artifactId}</name>
 
 	<dependencies>
+
+		<!-- *** Payara modules *** -->
+
+		<!-- *** Payara modules END *** -->
+
+		<!-- *** Domain libs *** -->
+
 		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-core</artifactId>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-server-spi</artifactId>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-server-spi-private</artifactId>
-			<scope>provided</scope>
 		</dependency>
+
+		<!-- *** Domain libs END *** -->
+
+		<!-- *** Compile dependencies *** -->
 
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>sormas-api</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>commons-codec</groupId>
-			<artifactId>commons-codec</artifactId>
-		</dependency>
+
+		<!-- *** Compile dependencies END *** -->
+
+		<!-- *** Test dependencies *** -->
+
+		<!-- *** Test dependencies END *** -->
+
 	</dependencies>
 
 	<build>

--- a/sormas-rest/pom.xml
+++ b/sormas-rest/pom.xml
@@ -17,63 +17,21 @@
 
 	<dependencies>
 
+		<!-- *** Payara modules *** -->
+
 		<dependency>
 			<groupId>javax</groupId>
 			<artifactId>javaee-web-api</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>com.opencsv</groupId>
-			<artifactId>opencsv</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>sormas-api</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.glassfish.jersey.containers</groupId>
-			<artifactId>jersey-container-servlet</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.glassfish.jersey.media</groupId>
-			<artifactId>jersey-media-json-jackson</artifactId>
-		</dependency>
-
 	  	<dependency>
 			<groupId>javax.security.enterprise</groupId>
 			<artifactId>javax.security.enterprise-api</artifactId>
 		</dependency>
 
 		<dependency>
-			<groupId>io.swagger.core.v3</groupId>
-			<artifactId>swagger-jaxrs2</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>io.swagger.core.v3</groupId>
-			<artifactId>swagger-jaxrs2-servlet-initializer-v2</artifactId>
-		</dependency>
-
-		<!-- Keycloak -->
-		<dependency>
-			<groupId>org.keycloak</groupId>
-			<artifactId>keycloak-servlet-filter-adapter</artifactId>
-		</dependency>
-
-		<!-- OpenID -->
-		<dependency>
 			<groupId>fish.payara.api</groupId>
 			<artifactId>payara-api</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>fish.payara.security.connectors</groupId>
 			<artifactId>security-connector-oidc-client</artifactId>
@@ -85,14 +43,26 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.glassfish.jersey.containers.glassfish</groupId>
-			<artifactId>jersey-gf-ejb</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.glassfish.soteria</groupId>
 			<artifactId>javax.security.enterprise</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.glassfish.jersey.containers.glassfish</groupId>
+			<artifactId>jersey-gf-ejb</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.core</groupId>
+			<artifactId>jersey-server</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.media</groupId>
+			<artifactId>jersey-media-json-jackson</artifactId>
+		</dependency>
+
+		<!-- *** Payara modules END *** -->
+
+		<!-- *** Domain libs *** -->
 
 		<dependency>
 			<groupId>com.google.guava</groupId>
@@ -101,6 +71,55 @@
 				Execution rest api of goal io.swagger.core.v3:swagger-maven-plugin:2.2.8:resolve failed: A required class was missing while 
 				executing io.swagger.core.v3:swagger-maven-plugin:2.2.8:resolve: com/google/common/collect/ImmutableMap -->
 		</dependency>
+
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>io.swagger.core.v3</groupId>
+			<artifactId>swagger-jaxrs2</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.swagger.core.v3</groupId>
+			<artifactId>swagger-jaxrs2-servlet-initializer-v2</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-collections4</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-servlet-filter-adapter</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+
+		<!-- *** Domain libs END *** -->
+
+		<!-- *** Test dependencies *** -->
+
+		<!-- *** Test dependencies END *** -->
+
+		<!-- *** Compile dependencies *** -->
+
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>sormas-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<!-- *** Compile dependencies END *** -->
 
 	</dependencies>
 

--- a/sormas-rest/src/main/java/de/symeda/sormas/rest/security/KeycloakIdentityStore.java
+++ b/sormas-rest/src/main/java/de/symeda/sormas/rest/security/KeycloakIdentityStore.java
@@ -22,7 +22,7 @@ import javax.security.enterprise.credential.CallerOnlyCredential;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.IdentityStore;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 
 import de.symeda.sormas.api.FacadeProvider;
 import de.symeda.sormas.api.user.UserDto;

--- a/sormas-rest/src/main/java/de/symeda/sormas/rest/security/SormasIdentityStore.java
+++ b/sormas-rest/src/main/java/de/symeda/sormas/rest/security/SormasIdentityStore.java
@@ -23,7 +23,7 @@ import javax.security.enterprise.credential.UsernamePasswordCredential;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.IdentityStore;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 
 import de.symeda.sormas.api.FacadeProvider;
 import de.symeda.sormas.api.user.UserRight;

--- a/sormas-serverlibs/pom.xml
+++ b/sormas-serverlibs/pom.xml
@@ -64,6 +64,10 @@
 			<artifactId>commons-beanutils</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
 		</dependency>
@@ -137,6 +141,11 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>jul-to-slf4j</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
 		</dependency>
 
 		<!-- *** Exclude Payara modules *** (with explicite scope "runtime") -->

--- a/sormas-serverlibs/pom.xml
+++ b/sormas-serverlibs/pom.xml
@@ -81,6 +81,15 @@
 		</dependency>
 
 		<dependency>
+			<groupId>io.swagger.core.v3</groupId>
+			<artifactId>swagger-jaxrs2</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.swagger.core.v3</groupId>
+			<artifactId>swagger-jaxrs2-servlet-initializer-v2</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
 		</dependency>
@@ -123,6 +132,11 @@
 		<dependency>
 			<groupId>org.jsoup</groupId>
 			<artifactId>jsoup</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-servlet-filter-adapter</artifactId>
 		</dependency>
 
 		<dependency>

--- a/sormas-serverlibs/pom.xml
+++ b/sormas-serverlibs/pom.xml
@@ -138,6 +138,18 @@
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-servlet-filter-adapter</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-server-spi</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-server-spi-private</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.postgresql</groupId>

--- a/sormas-serverlibs/pom.xml
+++ b/sormas-serverlibs/pom.xml
@@ -19,14 +19,21 @@
 		<!-- Transitive dependencies are automatically included (if not defined as exclusion) -->
 
 		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-structures-r4</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>org.hl7.fhir.r4</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-core</artifactId>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
@@ -42,6 +49,40 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.http-client</groupId>
+			<artifactId>google-http-client</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.google.http-client</groupId>
+			<artifactId>google-http-client-gson</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.oauth-client</groupId>
+			<artifactId>google-oauth-client</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.googlecode.libphonenumber</groupId>
+			<artifactId>libphonenumber</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.ibm.etcd</groupId>
+			<artifactId>etcd-java</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.jayway.jsonpath</groupId>
+			<artifactId>json-path</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.nexmo</groupId>
+			<artifactId>client</artifactId>
 		</dependency>
 
 		<dependency>
@@ -79,6 +120,19 @@
 			<groupId>commons-logging</groupId>
 			<artifactId>commons-logging</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>commons-validator</groupId>
+			<artifactId>commons-validator</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>fr.opensagres.xdocreport</groupId>
+			<artifactId>xdocreport</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>fr.opensagres.xdocreport</groupId>
+			<artifactId>fr.opensagres.xdocreport.template.velocity</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>io.swagger.core.v3</groupId>
@@ -112,12 +166,35 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.poi</groupId>
+			<artifactId>poi-ooxml</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.tika</groupId>
+			<artifactId>tika-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tika</groupId>
+			<artifactId>tika-parsers-standard-package</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcmail-jdk15on</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcpkix-jdk15on</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.docx4j</groupId>
+			<artifactId>docx4j-docx-anon</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.docx4j</groupId>
+			<artifactId>docx4j-JAXB-ReferenceImpl</artifactId>
 		</dependency>
 
 		<dependency>
@@ -134,6 +211,27 @@
 			<artifactId>jsoup</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.jboss.resteasy</groupId>
+			<artifactId>resteasy-client</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.resteasy</groupId>
+			<artifactId>resteasy-jackson2-provider</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.resteasy</groupId>
+			<artifactId>resteasy-jaxb-provider</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.resteasy</groupId>
+			<artifactId>resteasy-multipart-provider</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-admin-client</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-servlet-filter-adapter</artifactId>
@@ -154,6 +252,11 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.reflections</groupId>
+			<artifactId>reflections</artifactId>
 		</dependency>
 
 		<dependency>

--- a/sormas-ui/pom.xml
+++ b/sormas-ui/pom.xml
@@ -18,14 +18,79 @@
 
 	<dependencies>
 
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
-		</dependency>
+		<!-- *** Payara modules *** -->
+
 		<dependency>
 			<groupId>javax</groupId>
 			<artifactId>javaee-web-api</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>fish.payara.api</groupId>
+			<artifactId>payara-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>fish.payara.security.connectors</groupId>
+			<artifactId>security-connector-oidc-client</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.glassfish.corba</groupId>
+			<artifactId>glassfish-corba-omgapi</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.soteria</groupId>
+			<artifactId>javax.security.enterprise</artifactId>
+		</dependency>
+
+		<!-- *** Payara modules END *** -->
+
+		<!-- *** Domain libs *** -->
+
+		<dependency>
+			<groupId>com.opencsv</groupId>
+			<artifactId>opencsv</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-collections</groupId>
+			<artifactId>commons-collections</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-collections4</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+		</dependency>
+
+		<!-- *** Domain libs END *** -->
+
+		<!-- *** Compile dependencies *** -->
 
 		<dependency>
 			<groupId>${project.groupId}</groupId>
@@ -36,16 +101,6 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>sormas-widgetset</artifactId>
 			<version>${project.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.opencsv</groupId>
-			<artifactId>opencsv</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
 		</dependency>
 
 		<dependency>
@@ -72,12 +127,12 @@
 			<artifactId>wcslib-vaadin-widget-multifileupload</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context</artifactId>
-		</dependency>
+		<!-- *** Compile dependencies END *** -->
 
-		<!-- Testing -->
+		<!-- *** Test dependencies *** -->
+
+		<!-- Many dependencies needed for cdi-test with sormas-backend -->
+
 		<dependency>
 			<groupId>javax</groupId>
 			<artifactId>javaee-api</artifactId>
@@ -92,88 +147,82 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.github.mpkorstanje</groupId>
-			<artifactId>simmetrics-core</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-ehcache</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.hibernate.validator</groupId>
-			<artifactId>hibernate-validator</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.vladmihalcea</groupId>
-			<artifactId>hibernate-types-55</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.glassfish</groupId>
-			<artifactId>javax.el</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.glassfish.corba</groupId>
-			<artifactId>glassfish-corba-omgapi</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>de.hilling.junit.cdi</groupId>
 			<artifactId>cdi-test-core</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>
+			<groupId>com.github.mpkorstanje</groupId>
+			<artifactId>simmetrics-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-ehcache</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.vladmihalcea</groupId>
+			<artifactId>hibernate-types-55</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.glassfish</groupId>
+			<artifactId>javax.el</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-client</artifactId>
+			<scope>test</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.geronimo.config</groupId>
 			<artifactId>geronimo-config-impl</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-core</artifactId>
-		</dependency>
-
-		<!-- OpenID -->
-		<dependency>
-			<groupId>fish.payara.api</groupId>
-			<artifactId>payara-api</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>fish.payara.security.connectors</groupId>
-			<artifactId>security-connector-oidc-client</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.microprofile.config</groupId>
 			<artifactId>microprofile-config-api</artifactId>
+			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.glassfish.soteria</groupId>
-			<artifactId>javax.security.enterprise</artifactId>
-		</dependency>
+		<!-- *** Test dependencies END *** -->
 
 	</dependencies>
 

--- a/sormas-ui/pom.xml
+++ b/sormas-ui/pom.xml
@@ -199,8 +199,50 @@
 		</dependency>
 
 		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-structures-r4</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.ibm.etcd</groupId>
+			<artifactId>etcd-java</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.googlecode.libphonenumber</groupId>
+			<artifactId>libphonenumber</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.jayway.jsonpath</groupId>
+			<artifactId>json-path</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.nexmo</groupId>
+			<artifactId>client</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-validator</groupId>
+			<artifactId>commons-validator</artifactId>
 			<scope>test</scope>
 		</dependency>
 
@@ -211,14 +253,32 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.keycloak</groupId>
-			<artifactId>keycloak-core</artifactId>
+			<groupId>org.apache.poi</groupId>
+			<artifactId>poi-ooxml</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.tika</groupId>
+			<artifactId>tika-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.microprofile.config</groupId>
 			<artifactId>microprofile-config-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.reflections</groupId>
+			<artifactId>reflections</artifactId>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #11963

Progress:
- [x] 1. Moved most dependencies in all apps to serverlibs. Exclusions: 
    - `sormas-api`
    - All Vaadin dependencies (`sormas-ui`)
    - `gt-shapefile` (`sormas-backend`), see problem 3
- [x] 2. Don't duplicate glassfish/modules in serverlibs
- [x] 3. Verify deployment of apps in payara domain works
- [x] 4. Measure deployment time (see ticket description, run 7 after the changes)

Problems:
1. I needed to add more test dependencies explicitly for sormas-ui to keep EJB tests running (changing dependencies on sormas-backend from compile to provided meant there were not in the test classpath in sormas-ui any longer).
2. I struggled to move `resteasy` to serverlibs but was able to do it by updating it from 3.15.3 to 4.7.7 and exclude Jakarta APIs that had invalid POMs.
```
sormas-base\build.xml:88: Unable to resolve artifact: Unable to get dependency information: Unable to read the metadata file for artifact 'org.jboss.resteasy:resteasy-client:jar': Invalid JDK version in profile 'compile-java8-release-flag': Unbounded range: [9, for project org.jboss:jboss-parent
  org.jboss.resteasy:resteasy-client:jar:3.15.6.Final
```
3. I failed to move `gt-shapefile` to serverlibs because providing them with Ant fails.
<details>
<summary>Details for gt-shapefile problem</summary>
Exception when running Ant `collect-serverlibs`: `sormas-base\build.xml:88: org.apache.maven.artifact.InvalidArtifactRTException: For artifact {org.osgi:org.osgi.annotation:null:jar}: The version cannot be empty.`

```xml
<!-- trying in sormas-base/pom.xml to avoid the version problem by trying to set it or with exclusions: Did not help.

			<dependency>
				<groupId>org.osgi</groupId>
				<artifactId>org.osgi.annotation</artifactId>
				<version>6.0.0</version>
			</dependency>
			<dependency>
				<groupId>org.osgi</groupId>
				<artifactId>org.osgi.compendium</artifactId>
				<version>5.0.0</version>
			</dependency>
			<dependency>
				<groupId>org.osgi</groupId>
				<artifactId>org.osgi.core</artifactId>
				<version>6.0.0</version>
			</dependency>

			<dependency>
				<groupId>org.geotools</groupId>
				<artifactId>gt-shapefile</artifactId>
				<version>28.2</version>
				<scope>provided</scope>
				<exclusions>
					<exclusion>
						<groupId>org.osgi</groupId>
						<artifactId>org.osgi.annotation</artifactId>
					</exclusion>
					<exclusion>
						<groupId>org.osgi</groupId>
						<artifactId>org.osgi.compendium</artifactId>
					</exclusion>
					<exclusion>
						<groupId>org.osgi</groupId>
						<artifactId>org.osgi.core</artifactId>
					</exclusion>
				</exclusions>
			</dependency>

			<dependency>
				<groupId>systems.uom</groupId>
				<artifactId>systems-common</artifactId>
				<version>2.0.2</version>
				<scope>provided</scope>
				<!-- Used by gt-shapefile -->
				<exclusions>
					<exclusion>
						<groupId>org.osgi</groupId>
						<artifactId>org.osgi.annotation</artifactId>
					</exclusion>
					<exclusion>
						<groupId>org.osgi</groupId>
						<artifactId>org.osgi.compendium</artifactId>
					</exclusion>
					<exclusion>
						<groupId>org.osgi</groupId>
						<artifactId>org.osgi.core</artifactId>
					</exclusion>
				</exclusions>
			</dependency>
```

</details>

Follow up tickets:
- Avoid usage of commons-collections version 3, switch to collections4 and prevent usage with ArchUnit. commons-collections v3 will remain in classpath as transitive dependency.
- Replace Ant scripts by similarly easy to use Maven means. -> #12074 
- Provide `gt-shapefile` as serverlibs (when Ant is removed).