### PR TITLE
#11963 Keep hapi-fhir as compile dependency

### DIFF
--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -1093,11 +1093,16 @@
 				</exclusions>
 			</dependency>
 
+			<!-- *** Domain libs END *** -->
+
+			<!-- *** Compile dependencies *** -->
+
 			<dependency>
 				<groupId>ca.uhn.hapi.fhir</groupId>
 				<artifactId>hapi-fhir-structures-r4</artifactId>
 				<version>6.2.2</version>
-				<scope>provided</scope>
+				<scope>compile</scope>
+				<!-- Kept as compile dependency to avoid version conflicts and classpath problems with sormas-demis-adapter -->
 				<exclusions>
 					<!-- Exclude Payara modules here -->
 					<exclusion>
@@ -1118,12 +1123,9 @@
 				<groupId>ca.uhn.hapi.fhir</groupId>
 				<artifactId>org.hl7.fhir.r4</artifactId>
 				<version>5.6.88</version>
-				<scope>provided</scope>
+				<scope>compile</scope>
+				<!-- Kept as compile dependency to avoid version conflicts and classpath problems with sormas-demis-adapter -->
 			</dependency>
-
-			<!-- *** Domain libs END *** -->
-
-			<!-- *** Compile dependencies *** -->
 
 			<dependency>
 				<groupId>org.geotools</groupId>

--- a/sormas-serverlibs/pom.xml
+++ b/sormas-serverlibs/pom.xml
@@ -19,15 +19,6 @@
 		<!-- Transitive dependencies are automatically included (if not defined as exclusion) -->
 
 		<dependency>
-			<groupId>ca.uhn.hapi.fhir</groupId>
-			<artifactId>hapi-fhir-structures-r4</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>ca.uhn.hapi.fhir</groupId>
-			<artifactId>org.hl7.fhir.r4</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-core</artifactId>
 		</dependency>


### PR DESCRIPTION
- Avoids conflicts with sormas-demis-adapter

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #11963
- [x] Deployment without demis-adapter tested
- [x] Deployment with demis-adapter tested
- [ ] Integration of demis-adapter tested