### PR TITLE
Revert "Bump logback.version from 1.3.5 to 1.4.8 in /sormas-base"

### DIFF
--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -29,7 +29,7 @@
 
 		<!-- *** Other dependency versions *** -->
 		<slf4j.version>2.0.7</slf4j.version>
-		<logback.version>1.4.8</logback.version>
+		<logback.version>1.3.5</logback.version>
 		<vaadin.version.warning>TODO: Remove bootstrap.js in widgetset</vaadin.version.warning>
 		<vaadin.version>8.14.3</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>


### PR DESCRIPTION
Reverts SORMAS-Foundation/SORMAS-Project#12146 because logback 1.4.x requires Jakarta 9.