### PR TITLE
#12094 g-shapefile as serverlibs

### DIFF
--- a/sormas-backend/pom.xml
+++ b/sormas-backend/pom.xml
@@ -171,6 +171,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.geotools</groupId>
+			<artifactId>gt-shapefile</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-core</artifactId>
 		</dependency>
@@ -212,11 +217,6 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>sormas-api</artifactId>
 			<version>${project.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.geotools</groupId>
-			<artifactId>gt-shapefile</artifactId>
 		</dependency>
 
 		<!-- *** Compile dependencies END *** -->

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -779,6 +779,13 @@
 			</dependency>
 
 			<dependency>
+				<groupId>org.geotools</groupId>
+				<artifactId>gt-shapefile</artifactId>
+				<version>28.2</version>
+				<scope>provided</scope>
+			</dependency>
+
+			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-core</artifactId>
 				<version>5.6.15.Final</version>
@@ -1184,16 +1191,6 @@
 				<version>6.0.21</version>
 				<scope>compile</scope>
 				<!-- Kept as compile dependency to avoid version conflicts and classpath problems with sormas-demis-adapter -->
-			</dependency>
-
-			<dependency>
-				<groupId>org.geotools</groupId>
-				<artifactId>gt-shapefile</artifactId>
-				<version>28.2</version>
-				<!-- 
-				  Kept as compile dependency because Ant collect-serverlibs fails:
-				  sormas-base\build.xml:53: org.apache.maven.artifact.InvalidArtifactRTException: For artifact {org.osgi:org.osgi.annotation:null:jar}: The version cannot be empty.
-				-->
 			</dependency>
 
 			<!-- ** Vaadin ** -->

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -781,7 +781,7 @@
 			<dependency>
 				<groupId>org.geotools</groupId>
 				<artifactId>gt-shapefile</artifactId>
-				<version>28.2</version>
+				<version>29.2</version>
 				<scope>provided</scope>
 			</dependency>
 

--- a/sormas-serverlibs/pom.xml
+++ b/sormas-serverlibs/pom.xml
@@ -189,6 +189,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.geotools</groupId>
+			<artifactId>gt-shapefile</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-core</artifactId>
 		</dependency>


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #12094 

- [x] `gt-shapefile` with dependencies as serverlibs, updated to version 29.2.
- [x] Deployment works, showing region areas works. (my DEV instance)

Something odd I found: I did not have any regions. When I added "Niedersachsen", it showed up on the area where "Sachsen" is. After I added "Sachsen", "Niedersachsen" is shown correctly but "Sachsen" is now where "Sachsen-Anhalt" is. I assume it hase nothing to do with my ticket.
![grafik](https://github.com/SORMAS-Foundation/SORMAS-Project/assets/24678567/0c23fa89-ff71-4f7b-be3f-c11bbac4903f)
