### PR TITLE
Disable dependency check oss index to workarround rate limit issue

### DIFF
--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -1708,6 +1708,7 @@
 							<suppressionFile>${dependency-check.suppressionFile}</suppressionFile>
 						</suppressionFiles>
 						<assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+						<ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>
 					</configuration>
 					<executions>
 						<execution>


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->

Fixes problem described here https://github.com/jeremylong/DependencyCheck/issues/4539#issuecomment-1137183801
