### PR TITLE
#12666 Prevent district level users in the web app from editing sendi…

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/environmentsample/EnvironmentSampleEditForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/environmentsample/EnvironmentSampleEditForm.java
@@ -52,6 +52,7 @@ import de.symeda.sormas.api.i18n.Strings;
 import de.symeda.sormas.api.i18n.Validations;
 import de.symeda.sormas.api.infrastructure.facility.FacilityDto;
 import de.symeda.sormas.api.infrastructure.facility.FacilityReferenceDto;
+import de.symeda.sormas.api.user.JurisdictionLevel;
 import de.symeda.sormas.api.user.UserReferenceDto;
 import de.symeda.sormas.api.user.UserRight;
 import de.symeda.sormas.api.utils.DataHelper;
@@ -262,10 +263,12 @@ public class EnvironmentSampleEditForm extends AbstractEditForm<EnvironmentSampl
 
 	private void disableFieldsBasedOnRights(EnvironmentSampleDto sample) {
 		UserProvider currentUserProvider = UserProvider.getCurrent();
+		JurisdictionLevel jurisdictionLevel = currentUserProvider.getJurisdictionLevel();
 		boolean hasEditReceivalRight = currentUserProvider.hasUserRight(UserRight.ENVIRONMENT_SAMPLE_EDIT_RECEIVAL);
 		boolean hasEditDispatchRight = currentUserProvider.hasUserRight(UserRight.ENVIRONMENT_SAMPLE_EDIT_DISPATCH);
 		boolean isOwner = isCreate || DataHelper.isSame(sample.getReportingUser(), currentUserProvider.getUser());
-		boolean canEditDispatchField = isCreate || (isOwner && hasEditDispatchRight);
+		boolean canEditDispatchField =
+				isCreate || (hasEditDispatchRight && (isOwner || jurisdictionLevel.getOrder() >= JurisdictionLevel.REGION.getOrder()));
 
 		getFieldGroup().getFields().forEach(f -> {
 			if (f.isEnabled()) {


### PR DESCRIPTION
…ng information of environment samples that they have not created - allow access for users on region level or above

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #12666