### PR TITLE
#12846 Demis - Error has occurred when User click on the download mes…

### DIFF
--- a/sormas-backend/pom.xml
+++ b/sormas-backend/pom.xml
@@ -213,11 +213,11 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 
-        <dependency>
-            <groupId>org.apache.pdfbox</groupId>
-            <artifactId>pdfbox</artifactId>
-        </dependency>
-
+		<dependency>
+			<groupId>org.apache.pdfbox</groupId>
+			<artifactId>pdfbox</artifactId>
+			<version>3.0.0</version>
+		</dependency>
 
         <!-- *** Domain libs END *** -->
 

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -1172,13 +1172,6 @@
 				</exclusions>
 			</dependency>
 
-            <dependency>
-                <groupId>org.apache.pdfbox</groupId>
-                <artifactId>pdfbox</artifactId>
-                <version>3.0.0</version>
-                <scope>provided</scope>
-            </dependency>
-
 			<!-- *** Domain libs END *** -->
 
 			<!-- *** Compile dependencies *** -->

--- a/sormas-serverlibs/pom.xml
+++ b/sormas-serverlibs/pom.xml
@@ -289,11 +289,6 @@
 			<artifactId>spring-context</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.pdfbox</groupId>
-			<artifactId>pdfbox</artifactId>
-		</dependency>
-
 		<!-- *** Exclude Payara modules *** (with explicite scope "runtime") -->
 
 		<dependency>

--- a/sormas-ui/pom.xml
+++ b/sormas-ui/pom.xml
@@ -287,12 +287,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.pdfbox</groupId>
-			<artifactId>pdfbox</artifactId>
-			<scope>test</scope>
-		</dependency>
-
 		<!-- *** Test dependencies END *** -->
 
 	</dependencies>


### PR DESCRIPTION
…sage button

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #12846

Latest version of pdfbox added when implementing email attachments is not supported by the lib used for creating pdf form demis message, thus I removed the lates version from server libs and let demis adapter use the needed pdfbox dependency and the bacend module use the latest one