### PR TITLE
#12850 - 'Unsaved changes' pop-up is not triggered and 'Discard' butt…

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/UserField.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/UserField.java
@@ -5,7 +5,6 @@ import static de.symeda.sormas.ui.utils.CssStyles.LABEL_BOLD;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.vaadin.v7.shared.ui.textfield.AbstractTextFieldState;
 import org.apache.commons.lang3.StringUtils;
 
 import com.vaadin.icons.VaadinIcons;

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/UserField.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/UserField.java
@@ -32,7 +32,6 @@ public class UserField extends CustomField<UserReferenceDto> {
 	private boolean readOnly;
 	private boolean enabled;
 	private List<UserReferenceDto> items = new ArrayList<>();
-	private boolean valueChanged = false;
 
 	public UserField() {
 	}

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/UserField.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/UserField.java
@@ -5,6 +5,7 @@ import static de.symeda.sormas.ui.utils.CssStyles.LABEL_BOLD;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.vaadin.v7.shared.ui.textfield.AbstractTextFieldState;
 import org.apache.commons.lang3.StringUtils;
 
 import com.vaadin.icons.VaadinIcons;
@@ -31,6 +32,7 @@ public class UserField extends CustomField<UserReferenceDto> {
 	private boolean readOnly;
 	private boolean enabled;
 	private List<UserReferenceDto> items = new ArrayList<>();
+	private boolean valueChanged = false;
 
 	public UserField() {
 	}
@@ -62,7 +64,7 @@ public class UserField extends CustomField<UserReferenceDto> {
 		userCombo.setWidthFull();
 
 		userCombo.addValueChangeListener(valueChangeEvent -> {
-			setInternalValue((UserReferenceDto) userCombo.getValue());
+			super.setValue((UserReferenceDto) userCombo.getValue());
 		});
 
 		return userLayout;


### PR DESCRIPTION
…on does not take into account changes in the responsible user fields

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #12850 