### PR TITLE
#13337 - Fixed unable to process lab messages

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/externalmessage/ExternalMessage.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/externalmessage/ExternalMessage.java
@@ -224,6 +224,8 @@ public class ExternalMessage extends AbstractDomainObject {
 		this.caseClassification = caseClassification;
 	}
 
+	@Enumerated(EnumType.STRING)
+	@Column
 	public CaseClassification getCaseClassification() {
 		return caseClassification;
 	}


### PR DESCRIPTION
The problem was cause by missing annotation on the ExternalMessage class. Field CaseClassification was not annotated with String enum type.

- Added correct annotation to the CaseClassification field in the ExternalMessage class.

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #