### PR TITLE
#13356 - Notification box will always be visible

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/i18n/Captions.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/i18n/Captions.java
@@ -2154,6 +2154,7 @@ public interface Captions {
 	String nationalHealthId = "nationalHealthId";
 	String notAvailableShort = "notAvailableShort";
 	String Notification_dateOfNotification = "Notification.dateOfNotification";
+	String Notification_noNotification = "Notification.noNotification";
 	String notificationType = "notificationType";
 	String notificationType_caption = "notificationType.caption";
 	String notificationType_description = "notificationType.description";

--- a/sormas-api/src/main/resources/captions.properties
+++ b/sormas-api/src/main/resources/captions.properties
@@ -3485,3 +3485,4 @@ SystemConfigurationValue.General = General
 # Notifier
 Notifier.notification = Notification
 Notification.dateOfNotification = Date of notification
+Notification.noNotification = There are no notifications

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseDataView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseDataView.java
@@ -134,7 +134,7 @@ public class CaseDataView extends AbstractCaseView implements HasName {
 		final EditPermissionType caseEditAllowed = FacadeProvider.getCaseFacade().getEditPermissionType(uuid);
 		boolean isEditAllowed = isEditAllowed();
 
-		if (UiUtil.enabled(FeatureType.SURVEILLANCE_REPORTS) && caze.getNotifier() != null) {
+		if (UiUtil.enabled(FeatureType.SURVEILLANCE_REPORTS)) {
 			CaseNotifierSideViewComponent notifierSideViewComponent =
 				new CaseNotifierSideViewComponent(caze);
 			notifierSideViewComponent.addStyleNames(CssStyles.SIDE_COMPONENT);

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewComponent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewComponent.java
@@ -17,6 +17,7 @@ package de.symeda.sormas.ui.caze.notifier;
 
 import com.vaadin.icons.VaadinIcons;
 import com.vaadin.ui.Button;
+import com.vaadin.ui.Label;
 import com.vaadin.ui.themes.ValoTheme;
 
 import de.symeda.sormas.api.caze.CaseDataDto;
@@ -50,12 +51,13 @@ public class CaseNotifierSideViewComponent extends SideComponent {
 		if (caze.getNotifier() != null) {
 			var component = ControllerProvider.getCaseNotifierSideViewController().getNotifierComponent(caze);
 			addComponent(component);
+			Button notficationButton = ButtonHelper.createIconButton(Captions.Notifier_notification, VaadinIcons.BOOK, e -> {
+			}, ValoTheme.BUTTON_PRIMARY);
+
+			addCreateButton(notficationButton);
+		} else {
+			addComponent(new Label(I18nProperties.getCaption(Captions.Notification_noNotification)));
 		}
-
-		Button notficationButton = ButtonHelper.createIconButton(Captions.Notifier_notification, VaadinIcons.BOOK, e -> {
-		}, ValoTheme.BUTTON_PRIMARY);
-
-		addCreateButton(notficationButton);
 
 	}
 


### PR DESCRIPTION
Updated the `CaseDataView` to show the notification box even if there is no notifier.
In case there is no notifier, the notification
box will show a text message.

# Changes

- `Captions`
- `captions.properties`
- `CaseDataView`
- `CaseNotifierSideViewComponent`


Fixes #13356 