### PR TITLE
Bugfix 13353 changes system configuration admin UI

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/systemconfiguration/SystemConfigurationValueDiseasesProvider.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/systemconfiguration/SystemConfigurationValueDiseasesProvider.java
@@ -69,7 +69,8 @@ public class SystemConfigurationValueDiseasesProvider implements SystemConfigura
     public void applyValues(final Map<String, String> values, final SystemConfigurationValueDto dto) {
 
         if (null == values || values.isEmpty()) {
-            dto.setValue(null);
+            dto.setValue("");
+            return;
         }
         final String pipeSeparatedValues = values.keySet().stream().sorted(Comparator.naturalOrder()).collect(Collectors.joining("|"));
         dto.setValue(pipeSeparatedValues);

--- a/sormas-api/src/main/java/de/symeda/sormas/api/systemconfiguration/SystemConfigurationValueDiseasesProvider.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/systemconfiguration/SystemConfigurationValueDiseasesProvider.java
@@ -1,6 +1,6 @@
 /*
  * SORMAS® - Surveillance Outbreak Response Management & Analysis System
- * Copyright © 2016-2025 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
+ * Copyright © 2016-2026 SORMAS Foundation gGmbH
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,6 +17,7 @@ package de.symeda.sormas.api.systemconfiguration;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -68,9 +69,9 @@ public class SystemConfigurationValueDiseasesProvider implements SystemConfigura
     public void applyValues(final Map<String, String> values, final SystemConfigurationValueDto dto) {
 
         if (null == values || values.isEmpty()) {
-            return;
+            dto.setValue(null);
         }
-        final String pipeSeparatedValues = values.keySet().stream().collect(Collectors.joining("|"));
+        final String pipeSeparatedValues = values.keySet().stream().sorted(Comparator.naturalOrder()).collect(Collectors.joining("|"));
         dto.setValue(pipeSeparatedValues);
     }
 

--- a/sormas-api/src/main/resources/enum.properties
+++ b/sormas-api/src/main/resources/enum.properties
@@ -1646,6 +1646,7 @@ UserRight.SURVEY_TOKEN_CREATE=Create survey tokens
 UserRight.SURVEY_TOKEN_EDIT=Edit survey tokens
 UserRight.SURVEY_TOKEN_DELETE=Delete survey tokens
 UserRight.SURVEY_TOKEN_IMPORT=Import survey tokens
+UserRight.SYSTEM_CONFIGURATION=System configuration
 
 # UserRight descriptions
 UserRight.Desc.CASE_ARCHIVE = Able to archive cases
@@ -1879,6 +1880,7 @@ UserRight.Desc.SURVEY_TOKEN_CREATE=Able to create survey tokens
 UserRight.Desc.SURVEY_TOKEN_EDIT=Able to edit survey tokens
 UserRight.Desc.SURVEY_TOKEN_DELETE=Able to delete survey tokens
 UserRight.Desc.SURVEY_TOKEN_IMPORT=Able to import survey tokens
+UserRight.Desc.SYSTEM_CONFIGURATION=Able to access system configuration
 
 # UserRightGroup
 UserRightGroup.GENERAL = General

--- a/sormas-api/src/test/java/de/symeda/sormas/api/systemconfiguration/SystemConfigurationValueDiseasesProviderTest.java
+++ b/sormas-api/src/test/java/de/symeda/sormas/api/systemconfiguration/SystemConfigurationValueDiseasesProviderTest.java
@@ -102,7 +102,7 @@ class SystemConfigurationValueDiseasesProviderTest {
 
         provider.applyValues(values, dto);
 
-        assertThat(dto.getValue(), is((String) null));
+        assertThat(dto.getValue(), is(""));
     }
 
     /**

--- a/sormas-api/src/test/java/de/symeda/sormas/api/systemconfiguration/SystemConfigurationValueDiseasesProviderTest.java
+++ b/sormas-api/src/test/java/de/symeda/sormas/api/systemconfiguration/SystemConfigurationValueDiseasesProviderTest.java
@@ -127,7 +127,7 @@ class SystemConfigurationValueDiseasesProviderTest {
 
         provider.applyValues(values, dto);
 
-        assertThat(dto.getValue(), is((String) null));
+        assertThat(dto.getValue(), is(""));
     }
 
     /**

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/system/SystemConfigurationController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/system/SystemConfigurationController.java
@@ -1,6 +1,6 @@
 /*
  * SORMAS® - Surveillance Outbreak Response Management & Analysis System
- * Copyright © 2016-2026 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
+ * Copyright © 2016-2026 SORMAS Foundation gGmbH
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,10 +15,8 @@
 
 package de.symeda.sormas.ui.configuration.system;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.vaadin.ui.Notification;
+import com.vaadin.ui.Window;
 
 import de.symeda.sormas.api.FacadeProvider;
 import de.symeda.sormas.api.i18n.I18nProperties;
@@ -54,6 +52,8 @@ public class SystemConfigurationController {
             SormasUI.get().getNavigator().navigateTo(SystemConfigurationView.VIEW_NAME);
         });
 
-        VaadinUiUtil.showModalPopupWindow(cdw, EDIT + " " + systemConfigurationValue.getKey());
+        Window window = VaadinUiUtil.showModalPopupWindow(cdw, EDIT + " " + systemConfigurationValue.getKey());
+
     }
+
 }

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/system/SystemConfigurationValueDynamicInput.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/system/SystemConfigurationValueDynamicInput.java
@@ -1,6 +1,6 @@
 /*
  * SORMAS® - Surveillance Outbreak Response Management & Analysis System
- * Copyright © 2016-2025 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
+ * Copyright © 2016-2026 SORMAS Foundation gGmbH
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -16,6 +16,8 @@
 package de.symeda.sormas.ui.configuration.system;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -30,7 +32,6 @@ import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.PasswordField;
 import com.vaadin.ui.TextField;
 import com.vaadin.ui.VerticalLayout;
-import com.vaadin.ui.themes.ValoTheme;
 import com.vaadin.util.ReflectTools;
 
 import de.symeda.sormas.api.systemconfiguration.SystemConfigurationValueDataProvider;
@@ -85,6 +86,8 @@ public class SystemConfigurationValueDynamicInput extends CustomField<SystemConf
     }
 
     private static final String STYLE_NAME_DYNAMIC_INPUT = "system-configuration-dynamic-input";
+
+    private static final String STYLE_NAME_DYNAMIC_INPUT_FIXED_SIZE = "system-configuration-dynamic-input-fixed-size";
 
     private static final String STYLE_NAME_TOGGLE_PASSWORD = "toggle-password";
 
@@ -174,6 +177,7 @@ public class SystemConfigurationValueDynamicInput extends CustomField<SystemConf
             break;
         case CHECKBOX_GRID:
             mainLayout.addComponent(createCheckboxGrid());
+            mainLayout.addStyleName(STYLE_NAME_DYNAMIC_INPUT_FIXED_SIZE);
             break;
         case PASSWORD:
             mainLayout.addComponent(createPasswordField());
@@ -273,10 +277,11 @@ public class SystemConfigurationValueDynamicInput extends CustomField<SystemConf
     private CheckBoxGroup<String> createCheckboxGrid() {
 
         final var cbg = new CheckBoxGroup<String>();
-        cbg.setItems(getValue().getDataProvider().getOptions().values());
+        ArrayList<String> values = new ArrayList<>(getValue().getDataProvider().getOptions().values());
+        values.sort(Comparator.naturalOrder());
+        cbg.setItems(values);
         cbg.select(getValue().getDataProvider().getMappedValues(getValue()).values().toArray(new String[] {}));
         cbg.addValueChangeListener(event -> fireValueChange(cbg));
-        cbg.addStyleName(ValoTheme.OPTIONGROUP_HORIZONTAL);
         cbg.addStyleName(STYLE_NAME_WRAPPING_CHECKBOX_GROUP);
         cbg.setWidthFull();
         return cbg;

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/system/SystemConfigurationView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/system/SystemConfigurationView.java
@@ -1,6 +1,6 @@
 /*
  * SORMAS® - Surveillance Outbreak Response Management & Analysis System
- * Copyright © 2016-2026 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
+ * Copyright © 2016-2026 SORMAS Foundation gGmbH
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -21,7 +21,6 @@ import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.VerticalLayout;
 
 import de.symeda.sormas.api.FacadeProvider;
-import de.symeda.sormas.api.customizableenum.CustomizableEnumCriteria;
 import de.symeda.sormas.api.i18n.Captions;
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.i18n.Strings;
@@ -30,7 +29,6 @@ import de.symeda.sormas.api.systemconfiguration.SystemConfigurationValueCriteria
 import de.symeda.sormas.api.systemconfiguration.SystemConfigurationValueDto;
 import de.symeda.sormas.ui.ViewModelProviders;
 import de.symeda.sormas.ui.configuration.AbstractConfigurationView;
-import de.symeda.sormas.ui.configuration.customizableenum.CustomizableEnumValuesView;
 import de.symeda.sormas.ui.configuration.infrastructure.components.SearchField;
 import de.symeda.sormas.ui.utils.ButtonHelper;
 import de.symeda.sormas.ui.utils.CssStyles;
@@ -119,7 +117,7 @@ public class SystemConfigurationView extends AbstractConfigurationView {
         filterLayout.addComponent(categoryFilter);
 
         filterLayout.addComponent(ButtonHelper.createButton(Captions.actionResetFilters, event -> {
-            ViewModelProviders.of(CustomizableEnumValuesView.class).remove(CustomizableEnumCriteria.class);
+            ViewModelProviders.of(SystemConfigurationView.class).remove(SystemConfigurationValueCriteria.class);
             navigateTo(null);
         }, CssStyles.FORCE_CAPTION));
 

--- a/sormas-ui/src/main/webapp/VAADIN/themes/sormas/global.scss
+++ b/sormas-ui/src/main/webapp/VAADIN/themes/sormas/global.scss
@@ -443,6 +443,11 @@
     opacity: 0.5;
   }
 
+  .system-configuration-dynamic-input .system-configuration-dynamic-input-fixed-size {
+    height: 30rem;
+    overflow: auto;
+  }
+
   .system-configuration-dynamic-input .v-select-optiongroup-wrapping-checkbox-group {
     display: flex;
     flex-wrap: wrap;
@@ -450,34 +455,25 @@
   
   .system-configuration-dynamic-input .v-select-optiongroup-wrapping-checkbox-group > .v-checkbox {
     display: flex;
-    flex-grow: 1;
-    flex-shrink: 1;
-    align-items:stretch;
-    align-content:stretch;
-  }
-  
-  .system-configuration-dynamic-input .v-select-optiongroup-wrapping-checkbox-group > .v-checkbox label {
-    width:100%;
-    text-align:center;
-    border:1px solid;
+    width: calc(33.33% - 1.5rem);
   }
   
   .system-configuration-dynamic-input .toggle-password .v-spacing {
-    display:none;
+    display: none;
   }
   
   .system-configuration-dynamic-input .toggle-password .v-slot {
-    width:100% !important;
+    width: 100% !important;
   
   }
   
   .system-configuration-dynamic-input .toggle-password input {
-    height:36px;
+    height: 36px;
   }
   
   .system-configuration-dynamic-input .toggle-password .v-button { 
-    margin-left:-4rem;
-    margin-top:2px;
+    margin-left: -4rem;
+    margin-top: 2px;
   }
   
   .case-notifier-side-view {


### PR DESCRIPTION
Fixed issues with system configuration admin UI
Added ordering for the grouped checkbox values and allowed empty values:
- `SystemConfigurationValueDynamicInput`
- `SystemConfigurationValueDiseasesProvider`
- `SystemConfigurationController`

Fixed issue with reset filter not working:
- `SystemConfigurationView`

Added missing translations for system configuration:
- `enum.properties`


Fixes #13353 