### PR TITLE
#13357 - Add description field to system configuration values

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/i18n/Strings.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/i18n/Strings.java
@@ -1122,6 +1122,11 @@ public interface Strings {
 	String infoSurveyResponseNotReceived = "infoSurveyResponseNotReceived";
 	String infoSurveyResponseReceived = "infoSurveyResponseReceived";
 	String infoSyncUsers = "infoSyncUsers";
+	String infoSystemConfigurationValueDescriptionEmailSenderAddress = "infoSystemConfigurationValueDescriptionEmailSenderAddress";
+	String infoSystemConfigurationValueDescriptionEmailSenderName = "infoSystemConfigurationValueDescriptionEmailSenderName";
+	String infoSystemConfigurationValueDescriptionSmsAuthKey = "infoSystemConfigurationValueDescriptionSmsAuthKey";
+	String infoSystemConfigurationValueDescriptionSmsAuthSecret = "infoSystemConfigurationValueDescriptionSmsAuthSecret";
+	String infoSystemConfigurationValueDescriptionSmsSenderName = "infoSystemConfigurationValueDescriptionSmsSenderName";
 	String infoTasksWithMultipleJurisdictionsSelected = "infoTasksWithMultipleJurisdictionsSelected";
 	String infoUploadDocumentTemplate = "infoUploadDocumentTemplate";
 	String infoUsageOfEditableCampaignGrids = "infoUsageOfEditableCampaignGrids";

--- a/sormas-api/src/main/java/de/symeda/sormas/api/systemconfiguration/SystemConfigurationValueDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/systemconfiguration/SystemConfigurationValueDto.java
@@ -35,6 +35,7 @@ public class SystemConfigurationValueDto extends EntityDto {
 
     public static final String VALUE_PROPERTY_NAME = "value";
     public static final String KEY_PROPERTY_NAME = "key";
+    public static final String DESCRIPTION_PROPERTY_NAME = "description";
     public static final String CATEGORY_PROPERTY_NAME = "category";
     public static final String OPTIONAL_PROPERTY_NAME = "optional";
     public static final String PATTERN_PROPERTY_NAME = "pattern";
@@ -55,6 +56,9 @@ public class SystemConfigurationValueDto extends EntityDto {
     @NotNull(message = Validations.required)
     @Size(max = FieldConstraints.CHARACTER_LIMIT_TEXT, message = Validations.textTooLong)
     private String key;
+
+    @Size(max = FieldConstraints.CHARACTER_LIMIT_TEXT, message = Validations.textTooLong)
+    private String description;
 
     private SystemConfigurationCategoryReferenceDto category;
 
@@ -91,6 +95,7 @@ public class SystemConfigurationValueDto extends EntityDto {
     public SystemConfigurationValueDto(
         String value,
         String key,
+        String description,
         SystemConfigurationCategoryReferenceDto category,
         Boolean optional,
         String pattern,
@@ -99,6 +104,7 @@ public class SystemConfigurationValueDto extends EntityDto {
         String validationMessage) {
         this.value = value;
         this.key = key;
+        this.description = description;
         this.category = category;
         this.optional = optional;
         this.pattern = pattern;
@@ -121,6 +127,13 @@ public class SystemConfigurationValueDto extends EntityDto {
 
     public void setKey(final String key) {
         this.key = key;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(final String description) {
+        this.description = description;
     }
 
     public SystemConfigurationCategoryReferenceDto getCategory() {

--- a/sormas-api/src/main/java/de/symeda/sormas/api/systemconfiguration/SystemConfigurationValueFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/systemconfiguration/SystemConfigurationValueFacade.java
@@ -17,7 +17,6 @@ package de.symeda.sormas.api.systemconfiguration;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Optional;
 
 import javax.ejb.Remote;
 

--- a/sormas-api/src/main/java/de/symeda/sormas/api/systemconfiguration/SystemConfigurationValueIndexDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/systemconfiguration/SystemConfigurationValueIndexDto.java
@@ -28,6 +28,7 @@ public class SystemConfigurationValueIndexDto extends EntityDto {
 
     public static final String KEY_PROPERTY_NAME = "key";
     public static final String VALUE_PROPERTY_NAME = "value";
+    public static final String DESCRIPTION_PROPERTY_NAME = "description";
     public static final String ENCRYPTED_PROPERTY_NAME = "encrypted";
     public static final String CATEGORY_NAME_PROPERTY_NAME = "categoryName";
     public static final String CATEGORY_CAPTION_PROPERTY_NAME = "categoryCaption";
@@ -35,6 +36,7 @@ public class SystemConfigurationValueIndexDto extends EntityDto {
 
     private String value;
     private String key;
+    private String description;
     private boolean encrypted;
     private String categoryName;
     private String categoryCaption;
@@ -52,7 +54,8 @@ public class SystemConfigurationValueIndexDto extends EntityDto {
     /**
      * Sets the key of the configuration.
      * 
-     * @param key the key to set
+     * @param key
+     *            the key to set
      */
     public void setKey(String key) {
         this.key = key;
@@ -70,7 +73,8 @@ public class SystemConfigurationValueIndexDto extends EntityDto {
     /**
      * Sets the value of the configuration.
      * 
-     * @param value the value to set
+     * @param value
+     *            the value to set
      */
     public void setValue(String value) {
         this.value = value;
@@ -88,10 +92,30 @@ public class SystemConfigurationValueIndexDto extends EntityDto {
     /**
      * Sets the encryption status of the configuration value.
      * 
-     * @param encrypted the encryption status to set
+     * @param encrypted
+     *            the encryption status to set
      */
     public void setEncrypted(boolean encrypted) {
         this.encrypted = encrypted;
+    }
+
+    /**
+     * Gets the description of the configuration.
+     * 
+     * @return the description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Sets the description of the configuration.
+     * 
+     * @param description
+     *            the description to set
+     */
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     /**
@@ -106,7 +130,8 @@ public class SystemConfigurationValueIndexDto extends EntityDto {
     /**
      * Sets the category name of the configuration.
      * 
-     * @param categoryName the category name to set
+     * @param categoryName
+     *            the category name to set
      */
     public void setCategoryName(String categoryName) {
         this.categoryName = categoryName;
@@ -124,7 +149,8 @@ public class SystemConfigurationValueIndexDto extends EntityDto {
     /**
      * Sets the category caption of the configuration.
      * 
-     * @param categoryCaption the category caption to set
+     * @param categoryCaption
+     *            the category caption to set
      */
     public void setCategoryCaption(String categoryCaption) {
         this.categoryCaption = categoryCaption;
@@ -142,7 +168,8 @@ public class SystemConfigurationValueIndexDto extends EntityDto {
     /**
      * Sets the category description of the configuration.
      * 
-     * @param categoryDescription the category description to set
+     * @param categoryDescription
+     *            the category description to set
      */
     public void setCategoryDescription(String categoryDescription) {
         this.categoryDescription = categoryDescription;

--- a/sormas-api/src/main/resources/strings.properties
+++ b/sormas-api/src/main/resources/strings.properties
@@ -1952,3 +1952,9 @@ headingSelfReportCaseReportWithSameReferenceFound=Case self report with same cas
 confirmationSelfReportCaseReportWithSameReferenceFound=There is a case self report with the same case reference number as the processed self report.</br>It is recommended to process case reports first.</br></br>Do you want to continue processing this self report?
 headingSelfReportCaseWithSameReferenceNumberFound=Case with same reference number found
 confirmationSelfReportLinkContactToCaseWithSameReferenceNumber=There is a case with the same reference number as the contact found</br></br>Do you want to link this contact to that case?
+
+infoSystemConfigurationValueDescriptionEmailSenderAddress=Email address that will be set as the sender of email notifications sent out by the system.
+infoSystemConfigurationValueDescriptionEmailSenderName=Name that will be set as the sender of email notifications sent out by the system.
+infoSystemConfigurationValueDescriptionSmsSenderName=Name that will be set as the sender of SMS notifications sent out by the system.
+infoSystemConfigurationValueDescriptionSmsAuthKey=SORMAS supports the delivery of SMS notifications via Vonage (https://www.vonage.com/communications-apis/). You need to specify a valid authentication key and secret in order to use this feature. SORMAS will not attempt to send out SMS if these properties are left empty.
+infoSystemConfigurationValueDescriptionSmsAuthSecret=Secret for SMS authentication.

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/systemconfiguration/SystemConfigurationValue.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/systemconfiguration/SystemConfigurationValue.java
@@ -41,6 +41,7 @@ public class SystemConfigurationValue extends AbstractDomainObject {
 
     private String value;
     private String key;
+    private String description;
     private SystemConfigurationCategory category;
     private Boolean optional;
     private String pattern;
@@ -64,6 +65,15 @@ public class SystemConfigurationValue extends AbstractDomainObject {
 
     public void setKey(String key) {
         this.key = key;
+    }
+
+    @Column(nullable = true, name = "value_description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/systemconfiguration/SystemConfigurationValueEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/systemconfiguration/SystemConfigurationValueEjb.java
@@ -382,6 +382,7 @@ public class SystemConfigurationValueEjb
 
         target.setKey(source.getKey());
         target.setValue(source.getValue());
+        target.setDescription(source.getDescription());
         target.setCategory(categoryService.getByReferenceDto(source.getCategory()));
         target.setOptional(source.getOptional() != null ? source.getOptional() : Boolean.FALSE);
         target.setEncrypt(source.getEncrypt());
@@ -414,6 +415,7 @@ public class SystemConfigurationValueEjb
 
         target.setKey(source.getKey());
         target.setValue(source.getValue());
+        target.setDescription(source.getDescription());
         target.setCategory(
             source.getCategory() != null
                 ? categoryFacade.getReferenceByUuid(source.getCategory().getUuid())
@@ -518,6 +520,7 @@ public class SystemConfigurationValueEjb
 
         dto.setValue(entity.getValue());
         dto.setKey(entity.getKey());
+        dto.setDescription(entity.getDescription());
         dto.setEncrypted(entity.getEncrypt()); // encrypt needed for list view
         dto.setCategoryName(entity.getCategory() != null ? entity.getCategory().getName() : null);
         dto.setCategoryCaption(entity.getCategory() != null ? entity.getCategory().getCaption() : null);

--- a/sormas-backend/src/main/resources/sql/sormas_schema.sql
+++ b/sormas-backend/src/main/resources/sql/sormas_schema.sql
@@ -14197,4 +14197,35 @@ END $$
 LANGUAGE plpgsql;
 
 INSERT INTO schema_version (version_number, comment) VALUES (569, 'Moving Email & SMS properties to the new system configuration structure #13311');
+
+
+-- 2025-05-26 Add description to system configuration values #13357
+
+ALTER TABLE systemconfigurationvalue ADD COLUMN value_description text;
+ALTER TABLE systemconfigurationvalue_history ADD COLUMN value_description text;
+
+DO $$ BEGIN
+    UPDATE systemconfigurationvalue
+    SET value_description = 'i18n/systemConfigurationValueDescriptionEmailSenderAddress'
+    WHERE config_key = 'EMAIL_SENDER_ADDRESS';
+
+    UPDATE systemconfigurationvalue
+    SET value_description = 'i18n/systemConfigurationValueDescriptionEmailSenderName'
+    WHERE config_key = 'EMAIL_SENDER_NAME';
+
+    UPDATE systemconfigurationvalue
+    SET value_description = 'i18n/systemConfigurationValueDescriptionSmsSenderName'
+    WHERE config_key = 'SMS_SENDER_NAME';
+
+    UPDATE systemconfigurationvalue
+    SET value_description = 'i18n/systemConfigurationValueDescriptionSmsAuthKey'
+    WHERE config_key = 'SMS_AUTH_KEY';
+
+    UPDATE systemconfigurationvalue
+    SET value_description = 'i18n/systemConfigurationValueDescriptionSmsAuthSecret'
+    WHERE config_key = 'SMS_AUTH_SECRET';
+END $$ LANGUAGE plpgsql;
+
+INSERT INTO schema_version (version_number, comment) VALUES (570, 'Added description to system configuration values #13357');
+
 -- *** Insert new sql commands BEFORE this line. Remember to always consider _history tables. ***

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/system/SystemConfigurationValueEditForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/system/SystemConfigurationValueEditForm.java
@@ -18,8 +18,12 @@ package de.symeda.sormas.ui.configuration.system;
 import static de.symeda.sormas.ui.utils.LayoutUtil.locs;
 
 import com.vaadin.data.Binder;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.themes.ValoTheme;
 import com.vaadin.v7.ui.PasswordField;
 
+import de.symeda.sormas.api.i18n.Captions;
+import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.systemconfiguration.SystemConfigurationValueDto;
 import de.symeda.sormas.api.utils.fieldaccess.UiFieldAccessCheckers;
 import de.symeda.sormas.api.utils.fieldvisibility.FieldVisibilityCheckers;
@@ -30,9 +34,19 @@ import de.symeda.sormas.ui.utils.AbstractEditForm;
  */
 public class SystemConfigurationValueEditForm extends AbstractEditForm<SystemConfigurationValueDto> {
 
-	private static final String HTML_LAYOUT =
-		locs(SystemConfigurationValueDtoWrapper.WRAPPED_OBJECT_PROPERTY_NAME, SystemConfigurationValueDto.VALIDATION_MESSAGE_PROPERTY_NAME);
+	private static final String HTML_LAYOUT = locs(
+		SystemConfigurationValueDto.DESCRIPTION_PROPERTY_NAME,
+		SystemConfigurationValueDtoWrapper.WRAPPED_OBJECT_PROPERTY_NAME,
+		SystemConfigurationValueDto.VALIDATION_MESSAGE_PROPERTY_NAME);
 
+	/**
+	 * The label for displaying the description of the system configuration value.
+	 */
+	private Label descriptionLabel;
+
+	/**
+	 * The dynamic input field for the system configuration value.
+	 */
 	private final SystemConfigurationValueDynamicInput dynamicInput;
 
 	/**
@@ -53,10 +67,25 @@ public class SystemConfigurationValueEditForm extends AbstractEditForm<SystemCon
 		setWidth(640, Unit.PIXELS);
 		setValue(value);
 
+
+		if (value.getDescription() != null && !value.getDescription().isEmpty()) {
+			descriptionLabel = new Label(value.getDescription());
+
+			descriptionLabel.setWidth(600, Unit.PIXELS);
+			descriptionLabel.addStyleName(ValoTheme.LABEL_H3);
+
+			SystemConfigurationI18nHelper.processI18nString(
+				value.getDescription(),
+				(key) -> descriptionLabel.setValue(I18nProperties.getString(key)));
+
+			getContent().addComponent(descriptionLabel, SystemConfigurationValueDto.DESCRIPTION_PROPERTY_NAME);
+		}
+
+		dynamicInput = new SystemConfigurationValueDynamicInput();
+
 		final Binder<SystemConfigurationValueDtoWrapper> binder = new Binder<>(SystemConfigurationValueDtoWrapper.class);
 		binder.setBean(new SystemConfigurationValueDtoWrapper(value));
 
-		dynamicInput = new SystemConfigurationValueDynamicInput();
 		binder.forField(dynamicInput).bind(SystemConfigurationValueDtoWrapper.WRAPPED_OBJECT_PROPERTY_NAME);
 		getContent().addComponent(dynamicInput, SystemConfigurationValueDtoWrapper.WRAPPED_OBJECT_PROPERTY_NAME);
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/system/SystemConfigurationValuesGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/system/SystemConfigurationValuesGrid.java
@@ -15,6 +15,8 @@
 
 package de.symeda.sormas.ui.configuration.system;
 
+import com.vaadin.ui.Grid.Column;
+
 import de.symeda.sormas.api.FacadeProvider;
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.systemconfiguration.SystemConfigurationValueCriteria;
@@ -29,6 +31,9 @@ public class SystemConfigurationValuesGrid extends FilteredGrid<SystemConfigurat
 
 	private static final long serialVersionUID = 1L;
 
+	/**
+	 * The number of mask characters to generate for encrypted values.
+	 */
 	private static final int ENCRYPTED_VALUE_LENGTH = 15;
 
 	/**
@@ -58,14 +63,21 @@ public class SystemConfigurationValuesGrid extends FilteredGrid<SystemConfigurat
 
 		removeColumn(SystemConfigurationValueIndexDto.VALUE_PROPERTY_NAME);
 		addColumn(value -> value.isEncrypted() ? "*".repeat(ENCRYPTED_VALUE_LENGTH) : value.getValue())
-			.setId(SystemConfigurationValueIndexDto.VALUE_PROPERTY_NAME);
+			.setId(SystemConfigurationValueIndexDto.VALUE_PROPERTY_NAME)
+			.setDescriptionGenerator(v -> this.getValueDescription(v));
 
 		removeColumn(SystemConfigurationValueIndexDto.CATEGORY_NAME_PROPERTY_NAME);
-		addColumn(this::getCategoryCaption).setId(SystemConfigurationValueIndexDto.CATEGORY_NAME_PROPERTY_NAME);
+		addColumn(this::getCategoryCaption).setId(SystemConfigurationValueIndexDto.CATEGORY_NAME_PROPERTY_NAME)
+			.setDescriptionGenerator(v -> this.getValueDescription(v));
+
+		removeColumn(SystemConfigurationValueIndexDto.DESCRIPTION_PROPERTY_NAME);
+		addColumn(this::getValueDescription).setId(SystemConfigurationValueIndexDto.DESCRIPTION_PROPERTY_NAME)
+			.setDescriptionGenerator(v -> this.getValueDescription(v));
 
 		setColumns(
 			SystemConfigurationValueIndexDto.CATEGORY_NAME_PROPERTY_NAME,
 			SystemConfigurationValueIndexDto.KEY_PROPERTY_NAME,
+			SystemConfigurationValueIndexDto.DESCRIPTION_PROPERTY_NAME,
 			SystemConfigurationValueIndexDto.VALUE_PROPERTY_NAME);
 
 		addEditColumn(e -> ControllerProvider.getSystemConfigurationController().editSystemConfigurationValue(e.getUuid()));
@@ -87,6 +99,20 @@ public class SystemConfigurationValuesGrid extends FilteredGrid<SystemConfigurat
 			caption.append(value.getCategoryCaption());
 		}
 		return caption.toString();
+	}
+
+	private String getValueDescription(SystemConfigurationValueIndexDto value) {
+
+		if (value.getDescription() == null || value.getDescription().isEmpty()) {
+			return "";
+		}
+
+		final StringBuilder description = new StringBuilder();
+		SystemConfigurationI18nHelper.processI18nString(value.getDescription(), (key) -> description.append(I18nProperties.getString(key)));
+		if (description.length() == 0) {
+			description.append(value.getDescription());
+		}
+		return description.toString();
 	}
 
 	/**


### PR DESCRIPTION
Introduced a description field, and update backend, API, and UI to support displaying and editing the description. :

- `SystemConfigurationValue`
- `SystemConfigurationValueDto`
- `SystemConfigurationValueFacade`
- `SystemConfigurationValueEjb`
- `SystemConfigurationValueIndexDto`
- `SystemConfigurationValueEditForm`
- `SystemConfigurationValuesGrid`

Updated SQL schema to add value_description column:

- `sormas_schema.sql`

Added i18n keys and English texts for email and SMS configuration value descriptions :

- `Strings`
- `strings.properties`

