### PR TITLE
#13375 - Added EPI data hanling for doctor declaration processing

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/ExternalMessageDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/ExternalMessageDto.java
@@ -103,6 +103,8 @@ public class ExternalMessageDto extends SormasToSormasShareableDto {
 	public static final String TREATMENT_STARTED = "treatmentStarted";
 	public static final String TREATMENT_STARTED_DATE = "treatmentStartedDate";
 	public static final String DIAGNOSTIC_DATE = "diagnosticDate";
+	public static final String ACTIVITIES_AS_CASE = "activitiesAsCase";
+	public static final String EXPOSURES = "exposures";
 
 	@AuditIncludeProperty
 	private ExternalMessageType type;
@@ -219,6 +221,9 @@ public class ExternalMessageDto extends SormasToSormasShareableDto {
 
 	@Size(max = FieldConstraints.CHARACTER_LIMIT_SMALL, message = Validations.textTooLong)
 	private String notifierPhone;
+
+	private String activitiesAsCase;
+	private String exposures;
 
 	public ExternalMessageType getType() {
 		return type;
@@ -720,6 +725,22 @@ public class ExternalMessageDto extends SormasToSormasShareableDto {
 
 	public void setPersonAdditionalDetails(String personAdditionalDetails) {
 		this.personAdditionalDetails = personAdditionalDetails;
+	}
+
+	public String getActivitiesAsCase() {
+		return activitiesAsCase;
+	}
+
+	public void setActivitiesAsCase(String activitiesAsCase) {
+		this.activitiesAsCase = activitiesAsCase;
+	}
+
+	public String getExposures() {
+		return exposures;
+	}
+
+	public void setExposures(String exposures) {
+		this.exposures = exposures;
 	}
 
 }

--- a/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/processing/doctordeclaration/AbstractDoctorDeclarationMessageProcessingFlow.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/processing/doctordeclaration/AbstractDoctorDeclarationMessageProcessingFlow.java
@@ -1,6 +1,6 @@
 /*
  * SORMAS® - Surveillance Outbreak Response Management & Analysis System
- * Copyright © 2016-2023 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
+ * Copyright © 2016-2026 SORMAS Foundation gGmbH
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,11 +15,18 @@
 
 package de.symeda.sormas.api.externalmessage.processing.labmessage;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import de.symeda.sormas.api.activityascase.ActivityAsCaseDto;
+import de.symeda.sormas.api.activityascase.ActivityAsCaseType;
 import de.symeda.sormas.api.caze.CaseDataDto;
 import de.symeda.sormas.api.caze.CaseOutcome;
 import de.symeda.sormas.api.caze.CaseSelectionDto;
@@ -27,9 +34,12 @@ import de.symeda.sormas.api.caze.InvestigationStatus;
 import de.symeda.sormas.api.caze.surveillancereport.SurveillanceReportDto;
 import de.symeda.sormas.api.contact.ContactDto;
 import de.symeda.sormas.api.contact.SimilarContactDto;
+import de.symeda.sormas.api.epidata.EpiDataDto;
 import de.symeda.sormas.api.event.EventDto;
 import de.symeda.sormas.api.event.EventParticipantDto;
 import de.symeda.sormas.api.event.SimilarEventParticipantDto;
+import de.symeda.sormas.api.exposure.ExposureDto;
+import de.symeda.sormas.api.exposure.ExposureType;
 import de.symeda.sormas.api.externalmessage.ExternalMessageDto;
 import de.symeda.sormas.api.externalmessage.ExternalMessageStatus;
 import de.symeda.sormas.api.externalmessage.processing.AbstractMessageProcessingFlowBase;
@@ -45,6 +55,7 @@ import de.symeda.sormas.api.therapy.TherapyReferenceDto;
 import de.symeda.sormas.api.therapy.TreatmentDto;
 import de.symeda.sormas.api.user.UserDto;
 import de.symeda.sormas.api.utils.DtoCopyHelper;
+import de.symeda.sormas.api.utils.YesNoUnknown;
 import de.symeda.sormas.api.utils.dataprocessing.ProcessingResult;
 import de.symeda.sormas.api.utils.dataprocessing.flow.FlowThen;
 
@@ -231,11 +242,21 @@ public abstract class AbstractDoctorDeclarationMessageProcessingFlow extends Abs
 
 		postBuildCaseSymptoms(caseDto, externalMessageDto);
 		postBuildCaseTherapy(caseDto, externalMessageDto);
+		postBuildActivitiesAsCase(caseDto, externalMessageDto);
+		postBuildExposure(caseDto, externalMessageDto);
 
 		caseDto.setInvestigationStatus(InvestigationStatus.PENDING);
 		caseDto.setOutcome(CaseOutcome.NO_OUTCOME);
 	}
 
+	/**
+	 * Sets the symptoms for the case from the external message, if present.
+	 *
+	 * @param caseDto
+	 *            The case data transfer object to update.
+	 * @param externalMessageDto
+	 *            The external message containing symptom data.
+	 */
 	protected void postBuildCaseSymptoms(CaseDataDto caseDto, ExternalMessageDto externalMessageDto) {
 		if (externalMessageDto.getCaseSymptoms() != null) {
 			final SymptomsDto symptomsDto = SymptomsDto.build();
@@ -246,6 +267,14 @@ public abstract class AbstractDoctorDeclarationMessageProcessingFlow extends Abs
 		}
 	}
 
+	/**
+	 * Sets the therapy information for the case from the external message, if present.
+	 *
+	 * @param caseDto
+	 *            The case data transfer object to update.
+	 * @param externalMessageDto
+	 *            The external message containing therapy data.
+	 */
 	protected void postBuildCaseTherapy(CaseDataDto caseDto, ExternalMessageDto externalMessageDto) {
 
 		TherapyDto therapyDto = caseDto.getTherapy();
@@ -256,6 +285,112 @@ public abstract class AbstractDoctorDeclarationMessageProcessingFlow extends Abs
 
 		logger.debug("[POST BUILD CASE] Therapy set for case with UUID: {}", caseDto.getUuid());
 
+	}
+
+	/**
+	 * Sets the activities as case for the case from the external message, if present.
+	 * <p>
+	 * This method deserializes the activities as case from a JSON string in the external message
+	 * into a list of {@link ActivityAsCaseDto} objects. Each activity is built and copied, and if
+	 * the activity type is missing, it is set to {@link ActivityAsCaseType#UNKNOWN}.
+	 * If there are activities, the {@code activityAsCaseDetailsKnown} field is set to {@link YesNoUnknown#YES}.
+	 * </p>
+	 *
+	 * @param caseDto
+	 *            The case data transfer object to update.
+	 * @param externalMessageDto
+	 *            The external message containing activities as case data in JSON format.
+	 */
+	protected void postBuildActivitiesAsCase(CaseDataDto caseDto, ExternalMessageDto externalMessageDto) {
+
+		if (externalMessageDto.getActivitiesAsCase() != null && !externalMessageDto.getActivitiesAsCase().isEmpty()) {
+			final ArrayList<ActivityAsCaseDto> activitiesAsCase = new ArrayList<>();
+
+			try {
+				ObjectMapper objectMapper = new ObjectMapper();
+				List<ActivityAsCaseDto> deserialActivityAsCaseDtos =
+					objectMapper.readValue(externalMessageDto.getActivitiesAsCase(), new TypeReference<List<ActivityAsCaseDto>>() {
+					});
+				for (ActivityAsCaseDto activityAsCaseDto : deserialActivityAsCaseDtos) {
+					ActivityAsCaseDto newActivityAsCase = ActivityAsCaseDto.build(activityAsCaseDto.getActivityAsCaseType());
+					if (newActivityAsCase.getActivityAsCaseType() == null) {
+						newActivityAsCase.setActivityAsCaseType(ActivityAsCaseType.UNKNOWN);
+					}
+					DtoCopyHelper.copyDtoValues(newActivityAsCase, activityAsCaseDto, true, "uuid");
+					activitiesAsCase.add(newActivityAsCase);
+				}
+			} catch (Exception e) {
+				logger.error("[POST BUILD CASE] Error while processing activities as case for case with UUID: {}", caseDto.getUuid(), e);
+				return;
+			}
+
+			if (!activitiesAsCase.isEmpty()) {
+				EpiDataDto epiData = caseDto.getEpiData();
+				if (epiData == null) {
+					epiData = EpiDataDto.build();
+					caseDto.setEpiData(epiData);
+				}
+
+				epiData.setActivityAsCaseDetailsKnown(YesNoUnknown.YES);
+				epiData.setActivitiesAsCase(activitiesAsCase);
+			}
+
+		} else {
+			logger.debug("[POST BUILD CASE] No activities to set for case with UUID: {}", caseDto.getUuid());
+		}
+	}
+
+	/**
+	 * Sets the exposure information for the case from the external message, if present.
+	 * <p>
+	 * This method deserializes the exposures from a JSON string in the external message
+	 * into a list of {@link ExposureDto} objects. Each exposure is built and copied, and if
+	 * the exposure type is missing, it is set to {@link ExposureType#UNKNOWN}.
+	 * If there are exposures, the {@code exposureDetailsKnown} field is set to {@link YesNoUnknown#YES}.
+	 * </p>
+	 *
+	 * @param caseDto
+	 *            The case data transfer object to update.
+	 * @param externalMessageDto
+	 *            The external message containing exposure data in JSON format.
+	 */
+	protected void postBuildExposure(CaseDataDto caseDto, ExternalMessageDto externalMessageDto) {
+
+		if (externalMessageDto.getExposures() != null && !externalMessageDto.getExposures().isEmpty()) {
+			final ArrayList<ExposureDto> exposures = new ArrayList<>();
+
+			try {
+				ObjectMapper objectMapper = new ObjectMapper();
+				List<ExposureDto> deserialExposureDtos =
+					objectMapper.readValue(externalMessageDto.getExposures(), new TypeReference<List<ExposureDto>>() {
+					});
+				for (ExposureDto exposureDto : deserialExposureDtos) {
+					ExposureDto newExposure = ExposureDto.build(exposureDto.getExposureType());
+					if (newExposure.getExposureType() == null) {
+						newExposure.setExposureType(ExposureType.UNKNOWN);
+					}
+					DtoCopyHelper.copyDtoValues(newExposure, exposureDto, true, "uuid");
+					exposures.add(newExposure);
+				}
+			} catch (Exception e) {
+				logger.error("[POST BUILD CASE] Error while processing exposures for case with UUID: {}", caseDto.getUuid(), e);
+				return;
+			}
+
+			if (!exposures.isEmpty()) {
+				EpiDataDto epiData = caseDto.getEpiData();
+				if (epiData == null) {
+					epiData = EpiDataDto.build();
+					caseDto.setEpiData(epiData);
+				}
+
+				epiData.setExposureDetailsKnown(YesNoUnknown.YES);
+				epiData.setExposures(exposures);
+			}
+
+		} else {
+			logger.debug("[POST BUILD CASE] No exposures to set for case with UUID: {}", caseDto.getUuid());
+		}
 	}
 
 	/**

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/externalmessage/ExternalMessage.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/externalmessage/ExternalMessage.java
@@ -23,8 +23,10 @@ import javax.persistence.Transient;
 
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.TypeDefs;
 
 import com.vladmihalcea.hibernate.type.array.ListArrayType;
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.caze.CaseClassification;
@@ -46,7 +48,10 @@ import de.symeda.sormas.backend.symptoms.Symptoms;
 import de.symeda.sormas.backend.user.User;
 
 @Entity(name = ExternalMessage.TABLE_NAME)
-@TypeDef(name = "list-array", typeClass = ListArrayType.class)
+@TypeDefs({
+	@TypeDef(name = "list-array", typeClass = ListArrayType.class),
+	@TypeDef(name = "jsonb", typeClass = JsonBinaryType.class),
+	@TypeDef(name = "json", typeClass = JsonBinaryType.class) })
 public class ExternalMessage extends AbstractDomainObject {
 
 	public static final String TABLE_NAME = "externalmessage";
@@ -106,6 +111,9 @@ public class ExternalMessage extends AbstractDomainObject {
 	public static final String TREATMENT_STARTED = "treatmentStarted";
 	public static final String TREATMENT_STARTED_DATE = "treatmentStartedDate";
 	public static final String DIAGNOSTIC_DATE = "diagnosticDate";
+
+	public static final String ACTIVITIES_AS_CASE = "activitiesAsCase";
+	public static final String EXPOSURES = "exposures";
 
 	private ExternalMessageType type;
 	private Disease disease;
@@ -181,6 +189,9 @@ public class ExternalMessage extends AbstractDomainObject {
 
 	@Column(length = CHARACTER_LIMIT_SMALL)
 	private String notifierPhone;
+
+	private String activitiesAsCase;
+	private String exposures;
 
 	@Enumerated(EnumType.STRING)
 	public ExternalMessageType getType() {
@@ -691,5 +702,25 @@ public class ExternalMessage extends AbstractDomainObject {
 
 	public void setDiagnosticDate(Date diagnosticDate) {
 		this.diagnosticDate = diagnosticDate;
+	}
+
+	@Column
+	@Type(type = "jsonb")
+	public String getActivitiesAsCase() {
+		return activitiesAsCase;
+	}
+
+	public void setActivitiesAsCase(String activitiesAsCase) {
+		this.activitiesAsCase = activitiesAsCase;
+	}
+
+	@Column
+	@Type(type = "jsonb")
+	public String getExposures() {
+		return exposures;
+	}
+
+	public void setExposures(String exposures) {
+		this.exposures = exposures;
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/externalmessage/ExternalMessageFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/externalmessage/ExternalMessageFacadeEjb.java
@@ -196,6 +196,8 @@ public class ExternalMessageFacadeEjb implements ExternalMessageFacade {
 		target.setTreatmentStarted(source.getTreatmentStarted());
 		target.setTreatmentStartedDate(source.getTreatmentStartedDate());
 		target.setDiagnosticDate(source.getDiagnosticDate());
+		target.setActivitiesAsCase(source.getActivitiesAsCase());
+		target.setExposures(source.getExposures());
 
 		target.setReportId(source.getReportId());
 		if (source.getAssignee() != null) {
@@ -396,6 +398,8 @@ public class ExternalMessageFacadeEjb implements ExternalMessageFacade {
 		target.setTreatmentStarted(source.getTreatmentStarted());
 		target.setTreatmentStartedDate(source.getTreatmentStartedDate());
 		target.setDiagnosticDate(source.getDiagnosticDate());
+		target.setActivitiesAsCase(source.getActivitiesAsCase());
+		target.setExposures(source.getExposures());
 
 		target.setReportId(source.getReportId());
 		if (source.getSampleReports() != null) {

--- a/sormas-backend/src/main/resources/sql/sormas_schema.sql
+++ b/sormas-backend/src/main/resources/sql/sormas_schema.sql
@@ -14241,4 +14241,14 @@ ALTER TABLE symptoms_history ADD COLUMN coughsprovokevomiting varchar(255);
 
 INSERT INTO schema_version (version_number, comment) VALUES (571, 'Update Pertussis symptoms #13373');
 
+
+-- 2025-06-02 Add epi data to external message #13375
+
+ALTER TABLE externalmessage ADD COLUMN activitiesascase jsonb;
+ALTER TABLE externalmessage_history ADD COLUMN activitiesascase jsonb;
+ALTER TABLE externalmessage ADD COLUMN exposures jsonb;
+ALTER TABLE externalmessage_history ADD COLUMN exposures jsonb;
+
+INSERT INTO schema_version (version_number, comment) VALUES (572, 'Updated doctor declaration for Pertussis #13375');
+
 -- *** Insert new sql commands BEFORE this line. Remember to always consider _history tables. ***


### PR DESCRIPTION
Added fields for activities as case and exposures to external message:
- `ExternalMessageDto`
- `ExternalMessage`
- `ExternalMessageFacadeEjb`

Added handling of EPI data in `AbstractDoctorDeclarationMessageProcessingFlow`:
- creation of `Exposure` entries based on the `ExternalMessage.exposures` fields
- creation of 'ActivityAsCase` entries based on the `ExternalMessage.activitiesAsCase` fields' accordinlgy to the Pertussis documentation.

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #