### PR TITLE
#13415: Follow-up details should be visible for diseases without foll…

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/FieldHelper.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/FieldHelper.java
@@ -280,6 +280,23 @@ public final class FieldHelper {
 		}
 	}
 
+	@SuppressWarnings("rawtypes")
+	public static void setMultipleVisible(
+		final FieldGroup fieldGroup,
+		List<String> targetPropertyIds,
+		Function<Field, Boolean> isVisibleFunction,
+		Function<Field, Boolean> isClearedOnHidden) {
+		final List<? extends Field<?>> targetFields = targetPropertyIds.stream().map(id -> fieldGroup.getField(id)).collect(Collectors.toList());
+		targetFields.forEach(targetField -> {
+			final boolean visible = isVisibleFunction.apply(targetField);
+			final boolean clearOnHidden = isClearedOnHidden.apply(targetField);
+			targetField.setVisible(visible);
+			if (!visible && clearOnHidden && targetField.getValue() != null) {
+				targetField.clear();
+			}
+		});
+	}
+
 	public static void setCaptionWhen(Field<?> sourceField, Field<?> targetField, Object sourceValue, String matchCaption, String noMatchCaption) {
 		if (sourceField != null) {
 			// initialize


### PR DESCRIPTION
Added hiding for follow-up fields based on disease configuration.

- `ContactDataForm` Added evaluation of disease configuration follow-up enabled. Hidden follow-up fields based on this configuration.
- `FieldHelper` Added method to set multiple fields visible based on a condition.

