### PR TITLE
#13442, #13486 - Fixed dirty state handling in Health Conditions form

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/clinicalcourse/HealthConditionsForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/clinicalcourse/HealthConditionsForm.java
@@ -245,7 +245,11 @@ public class HealthConditionsForm extends AbstractEditForm<HealthConditionsDto> 
 
 	@Override
 	protected <F extends Field> F addFieldToLayout(CustomLayout layout, String propertyId, F field) {
-		field.addValueChangeListener(e -> fireValueChange(false));
+		field.addValueChangeListener(e -> {
+			if (this.isModified()) {
+				fireValueChange(false);
+			}
+		});
 
 		return super.addFieldToLayout(layout, propertyId, field);
 	}

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/CommitDiscardWrapperComponent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/CommitDiscardWrapperComponent.java
@@ -73,6 +73,7 @@ import de.symeda.sormas.api.location.LocationDto;
 import de.symeda.sormas.api.person.PersonDto;
 import de.symeda.sormas.api.user.UserRight;
 import de.symeda.sormas.ui.UiUtil;
+import de.symeda.sormas.ui.clinicalcourse.HealthConditionsForm;
 import de.symeda.sormas.ui.events.EventDataForm;
 import de.symeda.sormas.ui.location.AccessibleTextField;
 import de.symeda.sormas.ui.location.LocationEditForm;
@@ -298,6 +299,11 @@ public class CommitDiscardWrapperComponent<C extends Component> extends Vertical
 						.stream()
 						.filter(lf -> !(lf instanceof AccessibleTextField))
 						.anyMatch(Buffered::isModified)) {
+						dirty = true;
+					}
+				} else if (source instanceof HealthConditionsForm) {
+					final HealthConditionsForm healthConditionsForm = (HealthConditionsForm) source;
+					if (healthConditionsForm.isModified()) {
 						dirty = true;
 					}
 				} else if (source instanceof AccessibleTextField) {


### PR DESCRIPTION
The bug was caused by `HealthConditionsForm` not properly checking if the form was dirty. This has been fixed by ensuring that the form checks its dirty state before triggering events.

- `HealthConditionsForm` now correctly checks if the form is dirty before triggering save or discard changes events.
- `CommitDiscardWrapperComponent` added `HealthConditionsForm` to the list of components that can be checked for dirty state.
