### PR TITLE
#13425 - Refactor contact creation form to avoid unnecessary warnings for similar health IDs

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/ContactController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/ContactController.java
@@ -595,11 +595,10 @@ public class ContactController {
 		} else {
 			disease = FacadeProvider.getEventFacade().getEventByUuid(eventParticipant.getEvent().getUuid(), false).getDisease();
 		}
-		createForm = new ContactCreateForm(disease, false, false, true);
+		createForm = new ContactCreateForm(disease, false, false, true, true);
 
 		createForm.setValue(createNewContact(eventParticipant, disease));
 		createForm.setPerson(eventParticipant.getPerson());
-		createForm.setPersonDetailsReadOnly();
 		createForm.setDiseaseReadOnly();
 
 		final CommitDiscardWrapperComponent<ContactCreateForm> createComponent =
@@ -628,10 +627,9 @@ public class ContactController {
 	public CommitDiscardWrapperComponent<ContactCreateForm> getContactCreateComponent(PersonDto person) {
 		final ContactCreateForm createForm;
 
-		createForm = new ContactCreateForm(null, false, false, true);
+		createForm = new ContactCreateForm(null, false, false, true, true);
 		createForm.setValue(createNewContact(person));
 		createForm.setPerson(person);
-		createForm.setPersonDetailsReadOnly();
 
 		final CommitDiscardWrapperComponent<ContactCreateForm> createComponent =
 			new CommitDiscardWrapperComponent<>(createForm, UiUtil.permitted(UserRight.CONTACT_CREATE), createForm.getFieldGroup());

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/ContactCreateForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/ContactCreateForm.java
@@ -104,6 +104,7 @@ public class ContactCreateForm extends AbstractEditForm<ContactDto> {
 	private Disease disease;
 	private final Boolean hasCaseRelation;
 	private final boolean asSourceContact;
+	private final boolean isPersonReadOnly;
 	private NullableOptionGroup contactCategory;
 	private TextField contactProximityDetails;
 
@@ -123,10 +124,19 @@ public class ContactCreateForm extends AbstractEditForm<ContactDto> {
 	private final boolean showPersonSearchButton;
 	private Window warningSimilarPersons;
 
+	public ContactCreateForm(Disease disease, boolean hasCaseRelation, boolean asSourceContact, boolean showPersonSearchButton) {
+		this(disease, hasCaseRelation, asSourceContact, showPersonSearchButton, false);
+	}
+
 	/**
 	 * TODO use disease and case relation information given in ContactDto
 	 */
-	public ContactCreateForm(Disease disease, boolean hasCaseRelation, boolean asSourceContact, boolean showPersonSearchButton) {
+	public ContactCreateForm(
+		Disease disease,
+		boolean hasCaseRelation,
+		boolean asSourceContact,
+		boolean showPersonSearchButton,
+		boolean isPersonReadOnly) {
 		super(
 			ContactDto.class,
 			ContactDto.I18N_PREFIX,
@@ -137,6 +147,7 @@ public class ContactCreateForm extends AbstractEditForm<ContactDto> {
 		this.disease = disease;
 		this.hasCaseRelation = hasCaseRelation;
 		this.asSourceContact = asSourceContact;
+		this.isPersonReadOnly = isPersonReadOnly;
 		this.showPersonSearchButton = showPersonSearchButton;
 
 		addFields();
@@ -158,11 +169,18 @@ public class ContactCreateForm extends AbstractEditForm<ContactDto> {
 		addField(ContactDto.DISEASE_DETAILS, TextField.class);
 
 		personCreateForm = new PersonCreateForm(false, false, false, showPersonSearchButton);
+		if (isPersonReadOnly) {
+			personCreateForm.setPersonDetailsReadOnly();
+		}
 		personCreateForm.setWidth(100, Unit.PERCENTAGE);
 		personCreateForm.setValue(new PersonDto());
 		getContent().addComponent(personCreateForm, ContactDto.PERSON);
 
 		personCreateForm.getNationalHealthIdField().addTextFieldValueChangeListener(e -> {
+			// Only check if the health ID can be edited
+			if (!personCreateForm.getNationalHealthIdField().isEnabled()) {
+				return;
+			}
 			warningSimilarPersons = PersonFormHelper
 				.warningSimilarPersons(personCreateForm.getNationalHealthIdField().getValue(), null, () -> warningSimilarPersons = null);
 		});
@@ -404,10 +422,6 @@ public class ContactCreateForm extends AbstractEditForm<ContactDto> {
 
 	public void setPerson(PersonDto person, boolean isNewPerson) {
 		personCreateForm.setPerson(person, isNewPerson);
-	}
-
-	public void setPersonDetailsReadOnly() {
-		personCreateForm.setPersonDetailsReadOnly();
 	}
 
 	public void setDiseaseReadOnly() {


### PR DESCRIPTION
- `ContactController` Replaced person readonly setting from method to constructor.
- `ContactCreateForm` Added person readonly flag to constructor and removed the method that set it.
