### PR TITLE
#13541 - Updated RSV hospitalization

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/hospitalization/HospitalizationDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/hospitalization/HospitalizationDto.java
@@ -52,6 +52,9 @@ public class HospitalizationDto extends EntityDto {
 	public static final String INTENSIVE_CARE_UNIT = "intensiveCareUnit";
 	public static final String INTENSIVE_CARE_UNIT_START = "intensiveCareUnitStart";
 	public static final String INTENSIVE_CARE_UNIT_END = "intensiveCareUnitEnd";
+	public static final String OXYGEN_PRESCRIBED = "oxygenPrescribed";
+	public static final String STILL_HOSPITALIZED = "stillHospitalized";
+	public static final String ICU_LENGTH_OF_STAY = "icuLengthOfStay";
 	public static final String HOSPITALIZATION_REASON = "hospitalizationReason";
 	public static final String OTHER_HOSPITALIZATION_REASON = "otherHospitalizationReason";
 	public static final String DESCRIPTION = "description";
@@ -73,6 +76,9 @@ public class HospitalizationDto extends EntityDto {
 	private YesNoUnknown intensiveCareUnit;
 	private Date intensiveCareUnitStart;
 	private Date intensiveCareUnitEnd;
+	private YesNoUnknown oxygenPrescribed;
+	private YesNoUnknown stillHospitalized;
+	private Integer icuLengthOfStay;
 	private HospitalizationReasonType hospitalizationReason;
 	@Size(max = FieldConstraints.CHARACTER_LIMIT_TEXT, message = Validations.textTooLong)
 	private String otherHospitalizationReason;
@@ -206,5 +212,29 @@ public class HospitalizationDto extends EntityDto {
 
 	public void setCurrentlyHospitalized(YesNoUnknown currentlyHospitalized) {
 		this.currentlyHospitalized = currentlyHospitalized;
+	}
+
+	public YesNoUnknown getOxygenPrescribed() {
+		return oxygenPrescribed;
+	}
+
+	public void setOxygenPrescribed(YesNoUnknown oxygenPrescribed) {
+		this.oxygenPrescribed = oxygenPrescribed;
+	}
+
+	public YesNoUnknown getStillHospitalized() {
+		return stillHospitalized;
+	}
+
+	public void setStillHospitalized(YesNoUnknown stillHospitalized) {
+		this.stillHospitalized = stillHospitalized;
+	}
+
+	public Integer getIcuLengthOfStay() {
+		return icuLengthOfStay;
+	}
+
+	public void setIcuLengthOfStay(Integer icuLengthOfStay) {
+		this.icuLengthOfStay = icuLengthOfStay;
 	}
 }

--- a/sormas-api/src/main/java/de/symeda/sormas/api/hospitalization/PreviousHospitalizationDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/hospitalization/PreviousHospitalizationDto.java
@@ -60,6 +60,9 @@ public class PreviousHospitalizationDto extends PseudonymizableDto {
 	public static final String INTENSIVE_CARE_UNIT = "intensiveCareUnit";
 	public static final String INTENSIVE_CARE_UNIT_START = "intensiveCareUnitStart";
 	public static final String INTENSIVE_CARE_UNIT_END = "intensiveCareUnitEnd";
+	public static final String ICU_LENGTH_OF_STAY = "icuLengthOfStay";
+	public static final String OXYGEN_PRESCRIBED = "oxygenPrescribed";
+	public static final String STILL_HOSPITALIZED = "stillHospitalized";
 
 	private YesNoUnknown admittedToHealthFacility;
 	private Date admissionDate;
@@ -89,6 +92,9 @@ public class PreviousHospitalizationDto extends PseudonymizableDto {
 	private YesNoUnknown intensiveCareUnit;
 	private Date intensiveCareUnitStart;
 	private Date intensiveCareUnitEnd;
+	private Integer icuLengthOfStay;
+	private YesNoUnknown oxygenPrescribed;
+	private YesNoUnknown stillHospitalized;
 
 	public static PreviousHospitalizationDto build(CaseDataDto caze) {
 
@@ -122,6 +128,9 @@ public class PreviousHospitalizationDto extends PseudonymizableDto {
 		previousHospitalization.setIntensiveCareUnit(hospitalization.getIntensiveCareUnit());
 		previousHospitalization.setIntensiveCareUnitStart(hospitalization.getIntensiveCareUnitStart());
 		previousHospitalization.setIntensiveCareUnitEnd(hospitalization.getIntensiveCareUnitEnd());
+		previousHospitalization.setIcuLengthOfStay(hospitalization.getIcuLengthOfStay());
+		previousHospitalization.setOxygenPrescribed(hospitalization.getOxygenPrescribed());
+		previousHospitalization.setStillHospitalized(hospitalization.getStillHospitalized());
 		previousHospitalization.setDescription(hospitalization.getDescription());
 
 		return previousHospitalization;
@@ -261,5 +270,29 @@ public class PreviousHospitalizationDto extends PseudonymizableDto {
 
 	public void setIntensiveCareUnitEnd(Date intensiveCareUnitEnd) {
 		this.intensiveCareUnitEnd = intensiveCareUnitEnd;
+	}
+
+	public Integer getIcuLengthOfStay() {
+		return icuLengthOfStay;
+	}
+
+	public void setIcuLengthOfStay(Integer icuLengthOfStay) {
+		this.icuLengthOfStay = icuLengthOfStay;
+	}
+
+	public YesNoUnknown getOxygenPrescribed() {
+		return oxygenPrescribed;
+	}
+
+	public void setOxygenPrescribed(YesNoUnknown oxygenPrescribed) {
+		this.oxygenPrescribed = oxygenPrescribed;
+	}
+
+	public YesNoUnknown getStillHospitalized() {
+		return stillHospitalized;
+	}
+
+	public void setStillHospitalized(YesNoUnknown stillHospitalized) {
+		this.stillHospitalized = stillHospitalized;
 	}
 }

--- a/sormas-api/src/main/java/de/symeda/sormas/api/i18n/Captions.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/i18n/Captions.java
@@ -897,6 +897,7 @@ public interface Captions {
 	String CaseHospitalization_healthFacility = "CaseHospitalization.healthFacility";
 	String CaseHospitalization_hospitalizationReason = "CaseHospitalization.hospitalizationReason";
 	String CaseHospitalization_hospitalizedPreviously = "CaseHospitalization.hospitalizedPreviously";
+	String CaseHospitalization_icuLengthOfStay = "CaseHospitalization.icuLengthOfStay";
 	String CaseHospitalization_intensiveCareUnit = "CaseHospitalization.intensiveCareUnit";
 	String CaseHospitalization_intensiveCareUnitEnd = "CaseHospitalization.intensiveCareUnitEnd";
 	String CaseHospitalization_intensiveCareUnitStart = "CaseHospitalization.intensiveCareUnitStart";
@@ -904,7 +905,9 @@ public interface Captions {
 	String CaseHospitalization_isolationDate = "CaseHospitalization.isolationDate";
 	String CaseHospitalization_leftAgainstAdvice = "CaseHospitalization.leftAgainstAdvice";
 	String CaseHospitalization_otherHospitalizationReason = "CaseHospitalization.otherHospitalizationReason";
+	String CaseHospitalization_oxygenPrescribed = "CaseHospitalization.oxygenPrescribed";
 	String CaseHospitalization_previousHospitalizations = "CaseHospitalization.previousHospitalizations";
+	String CaseHospitalization_stillHospitalized = "CaseHospitalization.stillHospitalized";
 	String caseImportErrorDescription = "caseImportErrorDescription";
 	String caseImportMergeCase = "caseImportMergeCase";
 	String caseInfrastructureDataChanged = "caseInfrastructureDataChanged";
@@ -935,14 +938,17 @@ public interface Captions {
 	String CasePreviousHospitalization_healthFacilityDepartment = "CasePreviousHospitalization.healthFacilityDepartment";
 	String CasePreviousHospitalization_healthFacilityDetails = "CasePreviousHospitalization.healthFacilityDetails";
 	String CasePreviousHospitalization_hospitalizationReason = "CasePreviousHospitalization.hospitalizationReason";
+	String CasePreviousHospitalization_icuLengthOfStay = "CasePreviousHospitalization.icuLengthOfStay";
 	String CasePreviousHospitalization_intensiveCareUnit = "CasePreviousHospitalization.intensiveCareUnit";
 	String CasePreviousHospitalization_intensiveCareUnitEnd = "CasePreviousHospitalization.intensiveCareUnitEnd";
 	String CasePreviousHospitalization_intensiveCareUnitStart = "CasePreviousHospitalization.intensiveCareUnitStart";
 	String CasePreviousHospitalization_isolated = "CasePreviousHospitalization.isolated";
 	String CasePreviousHospitalization_isolationDate = "CasePreviousHospitalization.isolationDate";
 	String CasePreviousHospitalization_otherHospitalizationReason = "CasePreviousHospitalization.otherHospitalizationReason";
+	String CasePreviousHospitalization_oxygenPrescribed = "CasePreviousHospitalization.oxygenPrescribed";
 	String CasePreviousHospitalization_prevHospPeriod = "CasePreviousHospitalization.prevHospPeriod";
 	String CasePreviousHospitalization_region = "CasePreviousHospitalization.region";
+	String CasePreviousHospitalization_stillHospitalized = "CasePreviousHospitalization.stillHospitalized";
 	String caseReferFromPointOfEntry = "caseReferFromPointOfEntry";
 	String caseSearchCase = "caseSearchCase";
 	String caseSearchSpecificCase = "caseSearchSpecificCase";

--- a/sormas-api/src/main/resources/captions.properties
+++ b/sormas-api/src/main/resources/captions.properties
@@ -645,6 +645,9 @@ CaseHospitalization.intensiveCareUnitEnd=End of the stay
 CaseHospitalization.hospitalizationReason=Reason for hospitalization
 CaseHospitalization.otherHospitalizationReason=Specify reason
 CaseHospitalization.currentlyHospitalized=Currently hospitalized?
+CaseHospitalization.oxygenPrescribed=Oxygen prescribed
+CaseHospitalization.stillHospitalized=Still hospitalized
+CaseHospitalization.icuLengthOfStay=Length of ICU stay (days)
 # CaseImport
 caseImportErrorDescription=Error description
 caseImportMergeCase=Override existing case with changes from the imported case?
@@ -670,6 +673,9 @@ CasePreviousHospitalization.otherHospitalizationReason=Specify reason
 CasePreviousHospitalization.intensiveCareUnit=Stay in the intensive care unit
 CasePreviousHospitalization.intensiveCareUnitStart=Start of the stay
 CasePreviousHospitalization.intensiveCareUnitEnd=End of the stay
+CasePreviousHospitalization.icuLengthOfStay=Length of stay in the ICU
+CasePreviousHospitalization.oxygenPrescribed=Was oxygen prescribed during the hospitalization?
+CasePreviousHospitalization.stillHospitalized=Is the patient still hospitalized?
 # ClinicalVisit
 clinicalVisitNewClinicalVisit=New clinical assessment
 ClinicalVisit=Clinical assessment

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/hospitalization/Hospitalization.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/hospitalization/Hospitalization.java
@@ -54,6 +54,9 @@ public class Hospitalization extends AbstractDomainObject {
 	public static final String INTENSIVE_CARE_UNIT = "intensiveCareUnit";
 	public static final String INTENSIVE_CARE_UNIT_START = "intensiveCareUnitStart";
 	public static final String INTENSIVE_CARE_UNIT_END = "intensiveCareUnitEnd";
+	public static final String OXYGEN_PRESCRIBED = "oxygenPrescribed";
+	public static final String STILL_HOSPITALIZED = "stillHospitalized";
+	public static final String ICU_LENGTH_OF_STAY = "icuLengthOfStay";
 	public static final String DESCRIPTION = "description";
 
 	private YesNoUnknown admittedToHealthFacility;
@@ -69,6 +72,9 @@ public class Hospitalization extends AbstractDomainObject {
 	private YesNoUnknown intensiveCareUnit;
 	private Date intensiveCareUnitStart;
 	private Date intensiveCareUnitEnd;
+	private YesNoUnknown oxygenPrescribed;
+	private YesNoUnknown stillHospitalized;
+	private Integer icuLengthOfStay;
 	private HospitalizationReasonType hospitalizationReason;
 	private String otherHospitalizationReason;
 	private String description;
@@ -219,5 +225,31 @@ public class Hospitalization extends AbstractDomainObject {
 
 	public void setCurrentlyHospitalized(YesNoUnknown currentlyHospitalized) {
 		this.currentlyHospitalized = currentlyHospitalized;
+	}
+
+	@Enumerated(EnumType.STRING)
+	public YesNoUnknown getOxygenPrescribed() {
+		return oxygenPrescribed;
+	}
+
+	public void setOxygenPrescribed(YesNoUnknown oxygenPrescribed) {
+		this.oxygenPrescribed = oxygenPrescribed;
+	}
+
+	@Enumerated(EnumType.STRING)
+	public YesNoUnknown getStillHospitalized() {
+		return stillHospitalized;
+	}
+
+	public void setStillHospitalized(YesNoUnknown stillHospitalized) {
+		this.stillHospitalized = stillHospitalized;
+	}
+
+	public Integer getIcuLengthOfStay() {
+		return icuLengthOfStay;
+	}
+
+	public void setIcuLengthOfStay(Integer icuLengthOfStay) {
+		this.icuLengthOfStay = icuLengthOfStay;
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/hospitalization/HospitalizationFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/hospitalization/HospitalizationFacadeEjb.java
@@ -87,6 +87,9 @@ public class HospitalizationFacadeEjb implements HospitalizationFacade {
 		target.setIntensiveCareUnit(source.getIntensiveCareUnit());
 		target.setIntensiveCareUnitStart(source.getIntensiveCareUnitStart());
 		target.setIntensiveCareUnitEnd(source.getIntensiveCareUnitEnd());
+		target.setOxygenPrescribed(source.getOxygenPrescribed());
+		target.setStillHospitalized(source.getStillHospitalized());
+		target.setIcuLengthOfStay(source.getIcuLengthOfStay());
 		target.setDescription(source.getDescription());
 		target.setCurrentlyHospitalized(source.getCurrentlyHospitalized());
 
@@ -123,6 +126,9 @@ public class HospitalizationFacadeEjb implements HospitalizationFacade {
 		target.setIntensiveCareUnit(source.getIntensiveCareUnit());
 		target.setIntensiveCareUnitStart(source.getIntensiveCareUnitStart());
 		target.setIntensiveCareUnitEnd(source.getIntensiveCareUnitEnd());
+		target.setIcuLengthOfStay(source.getIcuLengthOfStay());
+		target.setOxygenPrescribed(source.getOxygenPrescribed());
+		target.setStillHospitalized(source.getStillHospitalized());
 
 		return target;
 	}
@@ -157,6 +163,9 @@ public class HospitalizationFacadeEjb implements HospitalizationFacade {
 		target.setIntensiveCareUnit(source.getIntensiveCareUnit());
 		target.setIntensiveCareUnitStart(source.getIntensiveCareUnitStart());
 		target.setIntensiveCareUnitEnd(source.getIntensiveCareUnitEnd());
+		target.setOxygenPrescribed(source.getOxygenPrescribed());
+		target.setStillHospitalized(source.getStillHospitalized());
+		target.setIcuLengthOfStay(source.getIcuLengthOfStay());
 		target.setDescription(source.getDescription());
 		target.setCurrentlyHospitalized(source.getCurrentlyHospitalized());
 
@@ -190,6 +199,9 @@ public class HospitalizationFacadeEjb implements HospitalizationFacade {
 		target.setIntensiveCareUnit(source.getIntensiveCareUnit());
 		target.setIntensiveCareUnitStart(source.getIntensiveCareUnitStart());
 		target.setIntensiveCareUnitEnd(source.getIntensiveCareUnitEnd());
+		target.setIcuLengthOfStay(source.getIcuLengthOfStay());
+		target.setOxygenPrescribed(source.getOxygenPrescribed());
+		target.setStillHospitalized(source.getStillHospitalized());
 
 		return target;
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/hospitalization/PreviousHospitalization.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/hospitalization/PreviousHospitalization.java
@@ -82,6 +82,9 @@ public class PreviousHospitalization extends AbstractDomainObject {
 	private YesNoUnknown intensiveCareUnit;
 	private Date intensiveCareUnitStart;
 	private Date intensiveCareUnitEnd;
+	private Integer icuLengthOfStay;
+	private YesNoUnknown oxygenPrescribed;
+	private YesNoUnknown stillHospitalized;
 
 	@Enumerated(EnumType.STRING)
 	public YesNoUnknown getAdmittedToHealthFacility() {
@@ -243,5 +246,31 @@ public class PreviousHospitalization extends AbstractDomainObject {
 
 	public void setIntensiveCareUnitEnd(Date intensiveCareUnitEnd) {
 		this.intensiveCareUnitEnd = intensiveCareUnitEnd;
+	}
+
+	public Integer getIcuLengthOfStay() {
+		return icuLengthOfStay;
+	}
+
+	public void setIcuLengthOfStay(Integer icuLengthOfStay) {
+		this.icuLengthOfStay = icuLengthOfStay;
+	}
+
+	@Enumerated(EnumType.STRING)
+	public YesNoUnknown getOxygenPrescribed() {
+		return oxygenPrescribed;
+	}
+
+	public void setOxygenPrescribed(YesNoUnknown oxygenPrescribed) {
+		this.oxygenPrescribed = oxygenPrescribed;
+	}
+
+	@Enumerated(EnumType.STRING)
+	public YesNoUnknown getStillHospitalized() {
+		return stillHospitalized;
+	}
+
+	public void setStillHospitalized(YesNoUnknown stillHospitalized) {
+		this.stillHospitalized = stillHospitalized;
 	}
 }

--- a/sormas-backend/src/main/resources/sql/sormas_schema.sql
+++ b/sormas-backend/src/main/resources/sql/sormas_schema.sql
@@ -14525,4 +14525,24 @@ ALTER TABLE healthconditions_history ADD COLUMN IF NOT EXISTS immunodepression v
 
 INSERT INTO schema_version (version_number, comment) VALUES (585, 'RSV - Update Health Conditions section #13540');
 
+-- 2025-08-06 - RSV - Update Hospitalization #13541
+
+ALTER TABLE hospitalization ADD COLUMN IF NOT EXISTS oxygenPrescribed varchar(255);
+ALTER TABLE hospitalization ADD COLUMN IF NOT EXISTS stillHospitalized varchar(255);
+ALTER TABLE hospitalization ADD COLUMN IF NOT EXISTS icuLengthOfStay integer;
+
+ALTER TABLE hospitalization_history ADD COLUMN IF NOT EXISTS oxygenPrescribed varchar(255);
+ALTER TABLE hospitalization_history ADD COLUMN IF NOT EXISTS stillHospitalized varchar(255);
+ALTER TABLE hospitalization_history ADD COLUMN IF NOT EXISTS icuLengthOfStay integer;
+
+ALTER TABLE previoushospitalization ADD COLUMN IF NOT EXISTS oxygenPrescribed varchar(255);
+ALTER TABLE previoushospitalization ADD COLUMN IF NOT EXISTS stillHospitalized varchar(255);
+ALTER TABLE previoushospitalization ADD COLUMN IF NOT EXISTS icuLengthOfStay integer;
+
+ALTER TABLE previoushospitalization_history ADD COLUMN IF NOT EXISTS oxygenPrescribed varchar(255);
+ALTER TABLE previoushospitalization_history ADD COLUMN IF NOT EXISTS stillHospitalized varchar(255);
+ALTER TABLE previoushospitalization_history ADD COLUMN IF NOT EXISTS icuLengthOfStay integer;
+
+INSERT INTO schema_version (version_number, comment) VALUES (586, 'RSV - Update Hospitalization #13541');
+
 -- *** Insert new sql commands BEFORE this line. Remember to always consider _history tables. ***

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/hospitalization/HospitalizationForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/hospitalization/HospitalizationForm.java
@@ -36,6 +36,7 @@ import com.vaadin.v7.ui.Field;
 import com.vaadin.v7.ui.TextArea;
 import com.vaadin.v7.ui.TextField;
 
+import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.FacadeProvider;
 import de.symeda.sormas.api.caze.CaseDataDto;
 import de.symeda.sormas.api.hospitalization.HospitalizationDto;
@@ -84,6 +85,7 @@ public class HospitalizationForm extends AbstractEditForm<HospitalizationDto> {
 							HospitalizationDto.INTENSIVE_CARE_UNIT_START,
 							3,
 							HospitalizationDto.INTENSIVE_CARE_UNIT_END)
+					+ fluidRowLocs(HospitalizationDto.ICU_LENGTH_OF_STAY, HospitalizationDto.OXYGEN_PRESCRIBED, HospitalizationDto.STILL_HOSPITALIZED)
 					+ fluidRowLocs(HospitalizationDto.ISOLATED, HospitalizationDto.ISOLATION_DATE, "")
 					+ fluidRowLocs(HospitalizationDto.DESCRIPTION) +
 			loc(PREVIOUS_HOSPITALIZATIONS_HEADING_LOC) +
@@ -150,6 +152,12 @@ public class HospitalizationForm extends AbstractEditForm<HospitalizationDto> {
 		intensiveCareUnitEnd.setVisible(false);
 		FieldHelper
 			.setVisibleWhen(intensiveCareUnit, Arrays.asList(intensiveCareUnitStart, intensiveCareUnitEnd), Arrays.asList(YesNoUnknown.YES), true);
+
+		// RSV-specific fields
+		final TextField icuLengthOfStayField = addField(HospitalizationDto.ICU_LENGTH_OF_STAY, TextField.class);
+		final NullableOptionGroup oxygenPrescribedField = addField(HospitalizationDto.OXYGEN_PRESCRIBED, NullableOptionGroup.class);
+		final NullableOptionGroup stillHospitalizedField = addField(HospitalizationDto.STILL_HOSPITALIZED, NullableOptionGroup.class);
+
 		final Field isolationDateField = addField(HospitalizationDto.ISOLATION_DATE);
 		final TextArea descriptionField = addField(HospitalizationDto.DESCRIPTION, TextArea.class);
 		descriptionField.setRows(4);
@@ -158,6 +166,25 @@ public class HospitalizationForm extends AbstractEditForm<HospitalizationDto> {
 
 		final ComboBox hospitalizationReason = addField(HospitalizationDto.HOSPITALIZATION_REASON);
 		final TextField otherHospitalizationReason = addField(HospitalizationDto.OTHER_HOSPITALIZATION_REASON, TextField.class);
+
+		// Default hospitalization reason to REPORTED_DISEASE for RSV cases
+		if (caze.getDisease() == Disease.RESPIRATORY_SYNCYTIAL_VIRUS && hospitalizationReason.getValue() == null) {
+			hospitalizationReason.setValue(HospitalizationReasonType.REPORTED_DISEASE);
+		}
+
+		// Add listener to trigger RSV hospitalization reason defaulting when admitted to health facility
+		admittedToHealthFacilityField.addValueChangeListener(event -> {
+			final Object eventValue = event.getProperty().getValue();
+			final boolean isAdmitted = eventValue != null && eventValue instanceof Collection<?>
+				? ((Collection<?>) eventValue).contains(YesNoUnknown.YES)
+				: false;
+			if (caze.getDisease() == Disease.RESPIRATORY_SYNCYTIAL_VIRUS
+				&& isAdmitted
+				&& hospitalizationReason.getValue() == null) {
+				hospitalizationReason.setValue(HospitalizationReasonType.REPORTED_DISEASE);
+			}
+		});
+
 		NullableOptionGroup hospitalizedPreviouslyField = addField(HospitalizationDto.HOSPITALIZED_PREVIOUSLY, NullableOptionGroup.class);
 		CssStyles.style(hospitalizedPreviouslyField, CssStyles.ERROR_COLOR_PRIMARY);
 		PreviousHospitalizationsField previousHospitalizationsField =
@@ -283,6 +310,20 @@ public class HospitalizationForm extends AbstractEditForm<HospitalizationDto> {
 		intensiveCareUnitEnd.addValueChangeListener(event -> intensiveCareUnitStart.markAsDirty());
 		hospitalizedPreviouslyField.addValueChangeListener(e -> updatePrevHospHint(hospitalizedPreviouslyField, previousHospitalizationsField));
 		previousHospitalizationsField.addValueChangeListener(e -> updatePrevHospHint(hospitalizedPreviouslyField, previousHospitalizationsField));
+
+		// RSV-specific conditional visibility logic
+		// stillHospitalized should not be visible/writable if discharge date is filled
+		dischargeDateField.addValueChangeListener(event -> {
+			boolean hasDischargeDate = dischargeDateField.getValue() != null;
+			stillHospitalizedField.setVisible(!hasDischargeDate);
+			stillHospitalizedField.setEnabled(!hasDischargeDate);
+			if (hasDischargeDate) {
+				stillHospitalizedField.setValue(null);
+			}
+		});
+
+		// Show icuLengthOfStay when ICU dates are not available but survey has length information
+		FieldHelper.setVisibleWhen(intensiveCareUnit, Collections.singletonList(icuLengthOfStayField), Arrays.asList(YesNoUnknown.YES), true);
 	}
 
 	private void updatePrevHospHint(NullableOptionGroup hospitalizedPreviouslyField, PreviousHospitalizationsField previousHospitalizationsField) {

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/hospitalization/PreviousHospitalizationEditForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/hospitalization/PreviousHospitalizationEditForm.java
@@ -70,6 +70,7 @@ public class PreviousHospitalizationEditForm extends AbstractEditForm<PreviousHo
 			PreviousHospitalizationDto.INTENSIVE_CARE_UNIT,
 			PreviousHospitalizationDto.INTENSIVE_CARE_UNIT_START,
 			PreviousHospitalizationDto.INTENSIVE_CARE_UNIT_END)
+		+ fluidRowLocs(PreviousHospitalizationDto.ICU_LENGTH_OF_STAY, PreviousHospitalizationDto.OXYGEN_PRESCRIBED, PreviousHospitalizationDto.STILL_HOSPITALIZED)
 		+ fluidRowLocs(PreviousHospitalizationDto.DESCRIPTION);
 
 	private NullableOptionGroup intensiveCareUnit;
@@ -134,6 +135,11 @@ public class PreviousHospitalizationEditForm extends AbstractEditForm<PreviousHo
 		intensiveCareUnitEnd.setVisible(false);
 		FieldHelper
 			.setVisibleWhen(intensiveCareUnit, Arrays.asList(intensiveCareUnitStart, intensiveCareUnitEnd), Arrays.asList(YesNoUnknown.YES), true);
+
+		// RSV-specific fields
+		final TextField icuLengthOfStayField = addField(PreviousHospitalizationDto.ICU_LENGTH_OF_STAY, TextField.class);
+		final NullableOptionGroup oxygenPrescribedField = addField(PreviousHospitalizationDto.OXYGEN_PRESCRIBED, NullableOptionGroup.class);
+		final NullableOptionGroup stillHospitalizedField = addField(PreviousHospitalizationDto.STILL_HOSPITALIZED, NullableOptionGroup.class);
 
 		healthFacilityCombo.setImmediate(true);
 
@@ -269,6 +275,20 @@ public class PreviousHospitalizationEditForm extends AbstractEditForm<PreviousHo
 				true,
 				true,
 				I18nProperties.getValidationError(Validations.beforeDate, intensiveCareUnitEnd.getCaption(), dischargeDate.getCaption())));
+
+		// RSV-specific conditional visibility logic
+		// stillHospitalized should not be visible/writable if discharge date is filled
+		dischargeDate.addValueChangeListener(event -> {
+			boolean hasDischargeDate = dischargeDate.getValue() != null;
+			stillHospitalizedField.setVisible(!hasDischargeDate);
+			stillHospitalizedField.setEnabled(!hasDischargeDate);
+			if (hasDischargeDate) {
+				stillHospitalizedField.setValue(null);
+			}
+		});
+
+		// Show icuLengthOfStay when ICU dates are not available but survey has length information
+		FieldHelper.setVisibleWhen(intensiveCareUnit, Collections.singletonList(icuLengthOfStayField), Arrays.asList(YesNoUnknown.YES), true);
 
 		FieldHelper.addSoftRequiredStyle(admissionDate, dischargeDate, facilityCommunity, healthFacilityDetails);
 


### PR DESCRIPTION
- Added fields `OXYGEN_PRESCRIBED`, `STILL_HOSPITALIZED`,`ICU_LENGTH_OF_STAY`
- Hospitalization reason is set to `Reported disease` by default in case of RSV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New hospitalization and previous-hospitalization fields: ICU length of stay, oxygen prescribed, and still hospitalized — available for entry and display.
  * Dynamic form behavior: "Still hospitalized" hides when a discharge date exists; ICU length of stay appears only when intensive care is indicated.
* **Documentation**
  * Updated captions/labels across the UI for the new hospitalization fields to support internationalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->