### PR TITLE
Fixed issue with samples creation always displaying for Doctor Declaration

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/processing/AbstractMessageProcessingFlowBase.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/processing/AbstractMessageProcessingFlowBase.java
@@ -255,7 +255,7 @@ public abstract class AbstractMessageProcessingFlowBase extends AbstractProcessi
         });
     }
 
-    private FlowThen<ExternalMessageProcessingResult> doPickOrCreateSamplesFlow(
+    protected FlowThen<ExternalMessageProcessingResult> doPickOrCreateSamplesFlow(
         Consumer<SampleSimilarityCriteria> addSampleSearchCriteria,
         BiFunction<Integer, ExternalMessageProcessingResult, CompletionStage<ProcessingResult<ExternalMessageProcessingResult>>> createSampleAndPathogenTests,
         FlowThen<ExternalMessageProcessingResult> flow) {


### PR DESCRIPTION
- The doctor declaration processing was showing sample creation options even when no relevant samples were available.
- Added check to ensure that sample creation options are only displayed when there are valid sample reports.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Doctor declarations now skip creating samples when sample reports contain no tests, preventing unnecessary processing and reducing noise. Existing behavior remains unchanged when tests are present.

* **Refactor**
  * Enhanced extensibility of message processing flows to allow tailored handling for specific message types, improving maintainability and enabling more precise processing logic without affecting user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->