### PR TITLE
#13423 - Increased case selection table row height by 1

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/components/caseselection/CaseSelectionGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/components/caseselection/CaseSelectionGrid.java
@@ -90,7 +90,7 @@ public class CaseSelectionGrid extends Grid {
 		getContainer().removeAllItems();
 		getContainer().addAll(cases);
 		this.refreshAllRows();
-		setHeightByRows(cases.size() > 0 ? (cases.size() <= 10 ? cases.size() : 10) : 1);
+		setHeightByRows(cases.size() > 0 ? (cases.size() <= 10 ? cases.size() : 10) : 2);
 	}
 
 	public void setCases(List<CaseSelectionDto> cases) {


### PR DESCRIPTION
In order to address a Firefox layout issue where the row of the case selection table was not fully
visible when there were no cases to display,
the initial number of rows displayed in
the case selection table was increased from 1 to 2.
