### PR TITLE
#13519 - Modify Disease.java to permit the view of INVASIVE_PNEUMOCOC…

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/Disease.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/Disease.java
@@ -86,7 +86,7 @@ public enum Disease
 	POST_IMMUNIZATION_ADVERSE_EVENTS_MILD(true, false, false, true, false, 0, true, false, false),
 	POST_IMMUNIZATION_ADVERSE_EVENTS_SEVERE(true, false, false, true, false, 0, true, false, false),
 	FHA(true, false, false, true, false, 0, true, false, false),
-	INVASIVE_PNEUMOCOCCAL_INFECTION(true, true, true, false, false, 0, false, false, false),
+	INVASIVE_PNEUMOCOCCAL_INFECTION(true, true, true, false, true, 7, false, false, false),
 	INVASIVE_MENINGOCOCCAL_INFECTION(true, true, true, false, true, 7, false, false, false),
 	OTHER(true, true, true, false, true, 21, false, false, false),
 	UNDEFINED(true, true, true, false, true, 0, false, false, false);


### PR DESCRIPTION
Fixes #13519

Modify Disease.java Enum to permit the view of IPI disease, in the window to create contact in the case tab.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Follow-up is now enabled by default for Invasive pneumococcal infection cases, with a preset duration of 7 days. New cases will automatically receive scheduled follow-up tasks and timelines without additional setup. Users can adjust follow-up settings as needed in case management. No changes were made to follow-up defaults for other diseases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->