### PR TITLE
#13555 - Fix editing Notifier in phone DD

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/notifier/NotifierService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/notifier/NotifierService.java
@@ -91,10 +91,14 @@ public class NotifierService extends AdoServiceWithUserFilterAndJurisdiction<Not
 
         final Timestamp timestamp = Timestamp.from(time);
 
-        final String sql = "SELECT * FROM ("
-            + "SELECT * FROM (SELECT * FROM notifier_history b WHERE b.uuid = :uuid AND changedate <= CAST(:changeDate AS TIMESTAMP) ORDER BY changedate DESC LIMIT 1) "
-            + "UNION SELECT * FROM notifier a WHERE a.uuid = :uuid) "
-            + "WHERE uuid = :uuid AND changedate <= CAST(:changeDate AS TIMESTAMP) ORDER BY changedate DESC LIMIT 1;";
+        final String sql = "SELECT " + "a.id AS id, a.uuid AS uuid," + "COALESCE(b.changedate, a.changedate) AS changedate,"
+            + "a.creationdate AS creationdate, a.change_user_id AS change_user_id,"
+            + "COALESCE(b.registrationnumber, a.registrationnumber) AS registrationnumber," + "COALESCE(b.firstname, a.firstname) AS firstname,"
+            + "COALESCE(b.lastname, a.lastname) AS lastname," + "COALESCE(b.address, a.address) AS address," + "COALESCE(b.email, a.email) AS email,"
+            + "COALESCE(b.phone, a.phone) AS phone, "+ "COALESCE(b.agentfirstname, a.agentfirstname) AS agentfirstname, "
+            + "COALESCE(b.agentlastname, a.agentlastname) AS agentlastname "+ "FROM notifier a " + "LEFT JOIN " + "(SELECT * FROM notifier_history "
+            + "WHERE uuid = :uuid AND changedate <= CAST(:changeDate AS TIMESTAMP) " + "ORDER BY changedate DESC LIMIT 1" + ") b ON a.uuid = b.uuid "
+            + "WHERE a.uuid = :uuid";
 
         Query query = em.createNativeQuery(sql, Notifier.class);
         query.setParameter("uuid", uuid);

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
@@ -144,8 +144,9 @@ public class CaseNotifierSideViewController {
             return;
         }
 
+        // We only edit the current version
         NotifierDto notifier =
-            FacadeProvider.getNotifierFacade().getByUuidAndTime(caze.getNotifier().getUuid(), caze.getNotifier().getVersionDate().toInstant());
+            FacadeProvider.getNotifierFacade().getByUuid(caze.getNotifier().getUuid());
         TherapyDto therapy = caze.getTherapy();
 
         openEditWindow(


### PR DESCRIPTION
- Restored previous query for retrieving notifier
- Changed the edit form to only edit the current version of the notifier


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Editing a notifier now always targets the current version, preventing unintended edits to historical snapshots.
  * Improved reliability when viewing notifier details as of a past date, ensuring fields reflect the correct historical state.

* **Refactor**
  * Optimized backend retrieval of notifier data at a given time for better consistency and performance without changing public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->