### PR TITLE
Default follow-up is enabled for AFP Influenza subtypes like A & B are inactive by default.

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/Disease.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/Disease.java
@@ -25,7 +25,7 @@ public enum Disease
 	implements
 	StatisticsGroupingKey {
 
-	AFP(true, true, true, false, false, 0, true, false, false),
+	AFP(true, true, true, false, true, 60, true, false, false),
 	CHOLERA(true, true, true, false, true, 5, true, false, false),
 	CONGENITAL_RUBELLA(true, true, true, false, true, 21, true, false, false),
 	CSM(true, true, true, false, false, 10, true, false, false),
@@ -70,9 +70,9 @@ public enum Disease
 	YAWS_ENDEMIC_SYPHILIS(true, false, false, true, false, 0, true, false, false),
 	MATERNAL_DEATHS(true, false, false, true, false, 0, true, false, false),
 	PERINATAL_DEATHS(true, false, false, true, false, 0, true, false, false),
-	INFLUENZA(false, false, false, false, false, 0, true, false, false),
-	INFLUENZA_A(true, true, true, false, false, 0, true, false, false),
-	INFLUENZA_B(true, true, true, false, false, 0, true, false, false),
+	INFLUENZA(true, false, false, false, false, 0, true, false, false),
+	INFLUENZA_A(false, true, true, false, false, 0, true, false, false),
+	INFLUENZA_B(false, true, true, false, false, 0, true, false, false),
 	H_METAPNEUMOVIRUS(true, false, true, false, false, 0, true, false, false),
 	RESPIRATORY_SYNCYTIAL_VIRUS(true, false, true, false, false, 0, true, false, false),
 	PARAINFLUENZA_1_4(true, false, true, false, false, 0, true, false, false),


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AFP follow-up settings to enable automatic follow-up with a 60-day duration.
  * Adjusted INFLUENZA disease classification flags to properly reflect disease categorization hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->