### PR TITLE
Further fixes for system configuration UI and reverted IPI follow-up …

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/Disease.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/Disease.java
@@ -86,7 +86,7 @@ public enum Disease
 	POST_IMMUNIZATION_ADVERSE_EVENTS_MILD(true, false, false, true, false, 0, true, false, false),
 	POST_IMMUNIZATION_ADVERSE_EVENTS_SEVERE(true, false, false, true, false, 0, true, false, false),
 	FHA(true, false, false, true, false, 0, true, false, false),
-	INVASIVE_PNEUMOCOCCAL_INFECTION(true, true, true, false, true, 7, false, false, false),
+	INVASIVE_PNEUMOCOCCAL_INFECTION(true, true, true, false, false, 0, false, false, false),
 	INVASIVE_MENINGOCOCCAL_INFECTION(true, true, true, false, true, 7, false, false, false),
 	GIARDIASIS(true, true, true, false, true, 14, false, false, false),
 	CRYPTOSPORIDIOSIS(true, true, true, false, true, 14, false, false, false),

--- a/sormas-api/src/main/java/de/symeda/sormas/api/systemconfiguration/SystemConfigurationValueIndexDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/systemconfiguration/SystemConfigurationValueIndexDto.java
@@ -30,7 +30,7 @@ public class SystemConfigurationValueIndexDto extends EntityDto {
     public static final String VALUE_PROPERTY_NAME = "value";
     public static final String DESCRIPTION_PROPERTY_NAME = "description";
     public static final String ENCRYPTED_PROPERTY_NAME = "encrypted";
-    public static final String CATEGORY_NAME_PROPERTY_NAME = "categoryName";
+    public static final String CATEGORY_NAME_PROPERTY_NAME = "category";
     public static final String CATEGORY_CAPTION_PROPERTY_NAME = "categoryCaption";
     public static final String CATEGORY_DESCRIPTION_PROPERTY_NAME = "categoryDescription";
 
@@ -38,7 +38,7 @@ public class SystemConfigurationValueIndexDto extends EntityDto {
     private String key;
     private String description;
     private boolean encrypted;
-    private String categoryName;
+    private String category;
     private String categoryCaption;
     private String categoryDescription;
 
@@ -123,18 +123,18 @@ public class SystemConfigurationValueIndexDto extends EntityDto {
      * 
      * @return the category name
      */
-    public String getCategoryName() {
-        return categoryName;
+    public String getCategory() {
+        return category;
     }
 
     /**
      * Sets the category name of the configuration.
      * 
-     * @param categoryName
+     * @param category
      *            the category name to set
      */
-    public void setCategoryName(String categoryName) {
-        this.categoryName = categoryName;
+    public void setCategory(String category) {
+        this.category = category;
     }
 
     /**

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/systemconfiguration/SystemConfigurationValueEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/systemconfiguration/SystemConfigurationValueEjb.java
@@ -263,6 +263,9 @@ public class SystemConfigurationValueEjb
             final List<Order> order = sortProperties.stream().map(sortProperty -> {
                 final Expression<?> expression;
                 switch (sortProperty.propertyName) {
+                case SystemConfigurationValue.CATEGORY_FIELD_NAME:
+                    expression = root.get(sortProperty.propertyName);
+                    break;
                 case SystemConfigurationValue.KEY_FIELD_NAME:
                     expression = cb.lower(root.get(sortProperty.propertyName));
                     break;
@@ -524,7 +527,7 @@ public class SystemConfigurationValueEjb
         dto.setKey(entity.getKey());
         dto.setDescription(entity.getDescription());
         dto.setEncrypted(entity.getEncrypt()); // encrypt needed for list view
-        dto.setCategoryName(entity.getCategory() != null ? entity.getCategory().getName() : null);
+        dto.setCategory(entity.getCategory() != null ? entity.getCategory().getName() : null);
         dto.setCategoryCaption(entity.getCategory() != null ? entity.getCategory().getCaption() : null);
         dto.setCategoryDescription(entity.getCategory() != null ? entity.getCategory().getDescription() : null);
 


### PR DESCRIPTION
Fixes System Configuration UI filtering issues, and reverted a change introduced by PR #13519.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default follow-up settings for invasive pneumococcal infection disease—follow-up is now disabled by default with zero-day duration.

* **Chores**
  * Refactored system configuration data structure for improved naming clarity and consistency. Added sorting capability for configuration categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->