### PR TITLE
#13669,#13664 - Fixed genotype not being filled in when processing a …

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/PathogenTestForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/PathogenTestForm.java
@@ -156,6 +156,8 @@ public class PathogenTestForm extends AbstractEditForm<PathogenTestDto> {
 	private Disease disease;
 	private TextField typingIdField;
 	private ComboBox specieField;
+	private ComboBox genoTypingCB;
+	private TextField genoTypingResultTextTF;
 	// List of tests that are used for serogrouping
 
 	public PathogenTestForm(
@@ -315,6 +317,13 @@ public class PathogenTestForm extends AbstractEditForm<PathogenTestDto> {
 		}
 		typingIdField.setValue(newFieldValue.getTypingId());
 		specieField.setValue(newFieldValue.getSpecie());
+		if(!genoTypingCB.isReadOnly()) {
+			genoTypingCB.setValue(newFieldValue.getGenoTypeResult());
+			// We only set the genotyping result text if the genotyping result is not read only
+			if(!genoTypingResultTextTF.isReadOnly()) {
+				genoTypingResultTextTF.setValue(newFieldValue.getGenoTypeResultText());
+			}
+		}
 		drugSusceptibilityField.forceUpdateDrugSusceptibilityFields();
 		markAsDirty();
 	}
@@ -389,9 +398,9 @@ public class PathogenTestForm extends AbstractEditForm<PathogenTestDto> {
 			diseaseVariantField.setCaption(I18nProperties.getCaption(Captions.PathogenTest_rsv_testedDiseaseVariant));
 			diseaseVariantDetailsField.setCaption(I18nProperties.getCaption(Captions.PathogenTest_rsv_testedDiseaseVariantDetails));
 		}
-		ComboBox genoTypingCB = addField(PathogenTestDto.GENOTYPE_RESULT, ComboBox.class);
+		genoTypingCB = addField(PathogenTestDto.GENOTYPE_RESULT, ComboBox.class);
 		genoTypingCB.setVisible(true);
-		TextField genoTypingResultTextTF = addField(PathogenTestDto.GENOTYPE_RESULT_TEXT, TextField.class);
+		genoTypingResultTextTF = addField(PathogenTestDto.GENOTYPE_RESULT_TEXT, TextField.class);
 		genoTypingResultTextTF.setVisible(true);
 
 		ComboBox testedPathogenField = addCustomizableEnumField(PathogenTestDto.TESTED_PATHOGEN);


### PR DESCRIPTION
Fixes:
- #13664
- #13669

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added genotyping selection and result text fields to the PathogenTest form
  * Fields are properly initialized and synchronized with form data states
  * Read-only configurations are respected for both new fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->