### PR TITLE
Fixed NPEs caused by List.of().contains(null) in PathogenTestForm.java

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/PathogenTestForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/PathogenTestForm.java
@@ -244,7 +244,8 @@ public class PathogenTestForm extends AbstractEditForm<PathogenTestDto> {
 		TextField cqValueField,
 		PathogenTestType testType,
 		PathogenTestResultType testResultType) {
-		if (!List.of(Disease.TUBERCULOSIS).contains((Disease) diseaseField.getValue())) {
+
+		if (diseaseField.getValue() == null || !List.of(Disease.TUBERCULOSIS).contains((Disease) diseaseField.getValue())) {
 			if (((testType == PathogenTestType.PCR_RT_PCR && testResultType == PathogenTestResultType.POSITIVE))
 				|| testType == PathogenTestType.CQ_VALUE_DETECTION) {
 				cqValueField.setVisible(true);
@@ -1211,7 +1212,7 @@ public class PathogenTestForm extends AbstractEditForm<PathogenTestDto> {
 
 				updateDrugSusceptibilityFieldSpecifications(testType, (Disease) diseaseField.getValue());
 
-				if (!List.of(Disease.TUBERCULOSIS).contains((Disease) diseaseField.getValue())) {
+				if (diseaseField.getValue() == null || !List.of(Disease.TUBERCULOSIS).contains((Disease) diseaseField.getValue())) {
 					setVisibleClear(
 						PathogenTestType.PCR_RT_PCR == testType,
 						PathogenTestDto.CQ_VALUE,


### PR DESCRIPTION
Fixes NPE's in `PathogenTestForm`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of the pathogen test form by ensuring consistent field visibility and behavior in edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->