### PR TITLE
#13740 - Fixed error when editing pathogen test in clinician view

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/NullableOptionGroup.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/NullableOptionGroup.java
@@ -89,6 +89,10 @@ public class NullableOptionGroup extends OptionGroup {
 		this.removeAllItems();
 		Item item = this.addItem(1);
 
+		if(item == null) {
+			return;
+		}
+
 		if (item.getItemPropertyIds().isEmpty()) {
 			return;
 		}


### PR DESCRIPTION
Fixes #13740 caused by Optional.empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option group components now more robustly handle inaccessible/unavailable items, ensuring consistent display and state when items are missing.

* **Bug Fixes**
  * Prevents errors and unintended behavior when an option has no properties or cannot be created, improving UI stability and interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->