### PR TITLE
Fixed issue in Therapy causing Beijing lineage flag to always be true

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/therapy/TherapyForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/therapy/TherapyForm.java
@@ -44,6 +44,7 @@ import de.symeda.sormas.api.caze.CaseDataDto;
 import de.symeda.sormas.api.i18n.Captions;
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.i18n.Strings;
+import de.symeda.sormas.api.sample.PathogenStrainCallStatus;
 import de.symeda.sormas.api.sample.PathogenTestDto;
 import de.symeda.sormas.api.sample.PathogenTestType;
 import de.symeda.sormas.api.sample.SampleDto;
@@ -437,7 +438,9 @@ public class TherapyForm extends AbstractEditForm<TherapyDto> {
 			}
 		}
 
-		if (latestBejingGenotypingTest != null) {
+		if (latestBejingGenotypingTest != null
+			&& latestBejingGenotypingTest.getStrainCallStatus() != null
+			&& latestBejingGenotypingTest.getStrainCallStatus() == PathogenStrainCallStatus.BEIJING) {
 			beijingLineageField.setValue(true);
 		}
 	}


### PR DESCRIPTION
Fixed #13769

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved strain identification validation to prevent errors and ensure accurate status verification before enabling the Beijing lineage feature.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->