### PR TITLE
fixed the empty PDF file downloading issue

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/externalmessage/ExternalMessageController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/externalmessage/ExternalMessageController.java
@@ -16,6 +16,7 @@ package de.symeda.sormas.ui.externalmessage;
 
 import static de.symeda.sormas.ui.externalmessage.processing.ExternalMessageProcessingUIHelper.showAlreadyProcessedPopup;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -417,6 +418,28 @@ public class ExternalMessageController {
 		return buttonsPanel;
 	}
 
+	/**
+	 * Downloads the attachment of an external message as byte array.
+	 * 
+	 * @param externalMessageUuid
+	 *            the UUID of the external message
+	 * @return the attachment as byte array wrapped in an Optional
+	 */
+	public Optional<byte[]> downloadExternalMessageAttachment(String externalMessageUuid) {
+
+		if (StringUtils.isBlank(externalMessageUuid)) {
+			return Optional.empty();
+		}
+
+		ExternalMessageDto externalMessageDto = FacadeProvider.getExternalMessageFacade().getByUuid(externalMessageUuid);
+
+		return Optional.ofNullable(externalMessageDto.getExternalMessageDetails().getBytes(StandardCharsets.UTF_8));
+	}
+
+	/**
+	 * Converts the external message to PDF format.
+	 * Keeping this method for future use cases.
+	 */
 	public Optional<byte[]> convertToPDF(String externalMessageUuid) {
 
 		ExternalMessageDto externalMessageDto = FacadeProvider.getExternalMessageFacade().getByUuid(externalMessageUuid);

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/externalmessage/ExternalMessageController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/externalmessage/ExternalMessageController.java
@@ -433,7 +433,7 @@ public class ExternalMessageController {
 
 		ExternalMessageDto externalMessageDto = FacadeProvider.getExternalMessageFacade().getByUuid(externalMessageUuid);
 
-		return Optional.ofNullable(externalMessageDto.getExternalMessageDetails().getBytes(StandardCharsets.UTF_8));
+		return Optional.ofNullable(externalMessageDto.getExternalMessageDetails()).map(details -> details.getBytes(StandardCharsets.UTF_8));
 	}
 
 	/**

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/externalmessage/ExternalMessageGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/externalmessage/ExternalMessageGrid.java
@@ -70,6 +70,7 @@ public class ExternalMessageGrid extends FilteredGrid<ExternalMessageIndexDto, E
 
 	private static final String PLACEHOLDER_SPACE = String.join("", Collections.nCopies(35, "&nbsp"));
 	private static final String PDF_FILENAME_FORMAT = "sormas_lab_message_%s_%s.pdf";
+	private static final String XML_FILENAME_FORMAT = "sormas_lab_message_%s_%s.xml";
 
 	private DataProviderListener<ExternalMessageIndexDto> dataProviderListener;
 
@@ -230,12 +231,15 @@ public class ExternalMessageGrid extends FilteredGrid<ExternalMessageIndexDto, E
 		Button downloadButton = new Button(VaadinIcons.DOWNLOAD);
 		downloadButton.setDescription(I18nProperties.getString(Strings.headingExternalMessageDownload));
 		final String fileName =
-			String.format(PDF_FILENAME_FORMAT, DataHelper.getShortUuid(labMessage.getUuid()), DateHelper.formatDateForExport(new Date()));
+			String.format(XML_FILENAME_FORMAT, DataHelper.getShortUuid(labMessage.getUuid()), DateHelper.formatDateForExport(new Date()));
 
 		StreamResource streamResource = new StreamResource(
-			() -> ControllerProvider.getExternalMessageController().convertToPDF(labMessage.getUuid()).map(ByteArrayInputStream::new).orElse(null),
+			() -> ControllerProvider.getExternalMessageController()
+				.downloadExternalMessageAttachment(labMessage.getUuid())
+				.map(ByteArrayInputStream::new)
+				.orElse(null),
 			fileName);
-		streamResource.setMIMEType("text/pdf");
+		streamResource.setMIMEType("application/xml");
 
 		FileDownloader fileDownloader = new FileDownloader(streamResource);
 		fileDownloader.extend(downloadButton);


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to download external message attachments in XML format.

* **Improvements**
  * Download now delivers the original XML attachment (replacing prior PDF conversion).
  * Filenames and content type updated to match XML downloads.

* **Bug Fixes**
  * Added validation to reject invalid/blank attachment requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->