### PR TITLE
#13775 - Moved treatment fields from therapy to cases

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseDataDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseDataDto.java
@@ -236,6 +236,10 @@ public class CaseDataDto extends SormasToSormasShareableDto implements IsCase {
 	public static final String RADIOGRAPHY_COMPATIBILITY = "radiographyCompatibility";
 	public static final String OTHER_DIAGNOSTIC_CRITERIA = "otherDiagnosticCriteria";
 
+	public static final String TREATMENT_STARTED = "treatmentStarted";
+	public static final String TREATMENT_NOT_APPLICABLE = "treatmentNotApplicable";
+	public static final String TREATMENT_START_DATE = "treatmentStartDate";
+
 	// Fields are declared in the order they should appear in the import template
 
 	@Outbreaks
@@ -440,6 +444,9 @@ public class CaseDataDto extends SormasToSormasShareableDto implements IsCase {
 	private EpiDataDto epiData;
 	@Valid
 	private TherapyDto therapy;
+	private YesNoUnknown treatmentStarted;
+	private boolean treatmentNotApplicable;
+	private Date treatmentStartDate;
 	@Valid
 	private ClinicalCourseDto clinicalCourse;
 	@Valid
@@ -1842,6 +1849,30 @@ public class CaseDataDto extends SormasToSormasShareableDto implements IsCase {
 
 	public void setOtherDiagnosticCriteria(String otherDiagnosticCriteria) {
 		this.otherDiagnosticCriteria = otherDiagnosticCriteria;
+	}
+
+	public YesNoUnknown getTreatmentStarted() {
+		return treatmentStarted;
+	}
+
+	public void setTreatmentStarted(YesNoUnknown treatmentStarted) {
+		this.treatmentStarted = treatmentStarted;
+	}
+
+	public boolean isTreatmentNotApplicable() {
+		return treatmentNotApplicable;
+	}
+
+	public void setTreatmentNotApplicable(boolean treatmentNotApplicable) {
+		this.treatmentNotApplicable = treatmentNotApplicable;
+	}
+
+	public Date getTreatmentStartDate() {
+		return treatmentStartDate;
+	}
+
+	public void setTreatmentStartDate(Date treatmentStartDate) {
+		this.treatmentStartDate = treatmentStartDate;
 	}
 
 	@JsonIgnore

--- a/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/processing/doctordeclaration/AbstractDoctorDeclarationMessageProcessingFlow.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/processing/doctordeclaration/AbstractDoctorDeclarationMessageProcessingFlow.java
@@ -56,7 +56,6 @@ import de.symeda.sormas.api.infrastructure.facility.FacilityType;
 import de.symeda.sormas.api.person.PersonDto;
 import de.symeda.sormas.api.sample.SampleSimilarityCriteria;
 import de.symeda.sormas.api.symptoms.SymptomsDto;
-import de.symeda.sormas.api.therapy.TherapyDto;
 import de.symeda.sormas.api.user.UserDto;
 import de.symeda.sormas.api.utils.DataHelper;
 import de.symeda.sormas.api.utils.DtoCopyHelper;
@@ -75,7 +74,7 @@ public abstract class AbstractDoctorDeclarationMessageProcessingFlow extends Abs
 
 	private final Logger logger = LoggerFactory.getLogger(getClass());
 
-	public AbstractDoctorDeclarationMessageProcessingFlow(
+	protected AbstractDoctorDeclarationMessageProcessingFlow(
 		ExternalMessageDto externalMessage,
 		UserDto user,
 		ExternalMessageMapper mapper,
@@ -146,7 +145,6 @@ public abstract class AbstractDoctorDeclarationMessageProcessingFlow extends Abs
 		postBuildCaseData(caseDto, externalMessageDto);
 		postBuildHealthConditions(caseDto, externalMessageDto);
 		postBuildCaseSymptoms(caseDto, externalMessageDto);
-		postBuildCaseTherapy(caseDto, externalMessageDto);
 		postBuildActivitiesAsCase(caseDto, externalMessageDto);
 		postBuildExposure(caseDto, externalMessageDto);
 		postBuildHospitalization(caseDto, externalMessageDto);
@@ -169,6 +167,11 @@ public abstract class AbstractDoctorDeclarationMessageProcessingFlow extends Abs
 			externalMessageDto.getCaseClassification() != null ? externalMessageDto.getCaseClassification() : caseDto.getCaseClassification());
 		caseDto.setRadiographyCompatibility(externalMessageDto.getRadiographyCompatibility());
 		caseDto.setOtherDiagnosticCriteria(externalMessageDto.getOtherDiagnosticCriteria());
+
+		caseDto.setTreatmentStarted(externalMessageDto.getTreatmentStarted());
+		caseDto.setTreatmentStartDate(externalMessageDto.getTreatmentStartedDate());
+		caseDto.setTreatmentNotApplicable(Boolean.TRUE.equals(externalMessageDto.getTreatmentNotApplicable()));
+
 	}
 
 	/**
@@ -233,26 +236,6 @@ public abstract class AbstractDoctorDeclarationMessageProcessingFlow extends Abs
 
 			logger.debug("[POST BUILD CASE] Symptoms set for case with UUID: {}", caseDto.getUuid());
 		}
-	}
-
-	/**
-	 * Sets the therapy information for the case from the external message, if present.
-	 *
-	 * @param caseDto
-	 *            The case data transfer object to update.
-	 * @param externalMessageDto
-	 *            The external message containing therapy data.
-	 */
-	protected void postBuildCaseTherapy(CaseDataDto caseDto, ExternalMessageDto externalMessageDto) {
-
-		TherapyDto therapyDto = caseDto.getTherapy();
-
-		therapyDto.setTreatmentStarted(externalMessageDto.getTreatmentStarted());
-		therapyDto.setTreatmentStartDate(externalMessageDto.getTreatmentStartedDate());
-		therapyDto.setTreatmentNotApplicable(Boolean.TRUE.equals(externalMessageDto.getTreatmentNotApplicable()));
-
-		logger.debug("[POST BUILD CASE] Therapy set for case with UUID: {}", caseDto.getUuid());
-
 	}
 
 	/**
@@ -415,7 +398,7 @@ public abstract class AbstractDoctorDeclarationMessageProcessingFlow extends Abs
 					caseDto.getUuid());
 				return;
 			}
-			
+
 			// we have a facility, so we set the responsible region, district and community
 			caseDto.setResponsibleRegion(hospitalFacility.getRegion());
 			caseDto.setResponsibleDistrict(hospitalFacility.getDistrict());

--- a/sormas-api/src/main/java/de/symeda/sormas/api/i18n/Captions.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/i18n/Captions.java
@@ -2239,6 +2239,7 @@ public interface Captions {
 	String Notification_noNotification = "Notification.noNotification";
 	String Notification_notificationTypeExternal = "Notification.notificationTypeExternal";
 	String Notification_notificationTypePhone = "Notification.notificationTypePhone";
+	String Notification_notifierInformation = "Notification.notifierInformation";
 	String Notification_registrationNumber = "Notification.registrationNumber";
 	String Notification_reportingAgent = "Notification.reportingAgent";
 	String Notification_viewNotification = "Notification.viewNotification";

--- a/sormas-api/src/main/java/de/symeda/sormas/api/i18n/Strings.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/i18n/Strings.java
@@ -1679,6 +1679,7 @@ public interface Strings {
 	String notificationContactSymptomatic = "notificationContactSymptomatic";
 	String notificationContactWithoutCaseSymptomatic = "notificationContactWithoutCaseSymptomatic";
 	String notificationCreationNotAllowedWithoutSurveillanceReport = "notificationCreationNotAllowedWithoutSurveillanceReport";
+	String notificationDiagnosisDateInformation = "notificationDiagnosisDateInformation";
 	String notificationDiseaseChanged = "notificationDiseaseChanged";
 	String notificationEventAddedToEventGroup = "notificationEventAddedToEventGroup";
 	String notificationEventGroupCreated = "notificationEventGroupCreated";
@@ -1697,6 +1698,7 @@ public interface Strings {
 	String notificationLabSampleShippedShort = "notificationLabSampleShippedShort";
 	String notificationLabSampleShippedShortForContact = "notificationLabSampleShippedShortForContact";
 	String notificationLabSampleShippedShortForEventParticipant = "notificationLabSampleShippedShortForEventParticipant";
+	String notificationNotificationDateInformation = "notificationNotificationDateInformation";
 	String notificationPersonsUpdated = "notificationPersonsUpdated";
 	String notificationSmsSent = "notificationSmsSent";
 	String notificationTaskAssociatedCaseLink = "notificationTaskAssociatedCaseLink";

--- a/sormas-api/src/main/java/de/symeda/sormas/api/therapy/TherapyDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/therapy/TherapyDto.java
@@ -17,13 +17,10 @@
  *******************************************************************************/
 package de.symeda.sormas.api.therapy;
 
-import java.util.Date;
-
 import de.symeda.sormas.api.EntityDto;
 import de.symeda.sormas.api.feature.FeatureType;
 import de.symeda.sormas.api.utils.DataHelper;
 import de.symeda.sormas.api.utils.DependingOnFeatureType;
-import de.symeda.sormas.api.utils.YesNoUnknown;
 
 @DependingOnFeatureType(featureType = FeatureType.CASE_SURVEILANCE)
 public class TherapyDto extends EntityDto {
@@ -36,16 +33,9 @@ public class TherapyDto extends EntityDto {
 	public static final String MDR_XDR_TUBERCULOSIS = "mdrXdrTuberculosis";
 	public static final String BEIJING_LINEAGE = "beijingLineage";
 
-	public static final String TREATMENT_STARTED = "treatmentStarted";
-	public static final String TREATMENT_NOT_APPLICABLE = "treatmentNotApplicable";
-
 	private boolean directlyObservedTreatment;
 	private boolean mdrXdrTuberculosis;
 	private boolean beijingLineage;
-
-	private YesNoUnknown treatmentStarted;
-	private boolean treatmentNotApplicable;
-	private Date treatmentStartDate;
 
 	public static TherapyDto build() {
 
@@ -80,29 +70,5 @@ public class TherapyDto extends EntityDto {
 
 	public void setBeijingLineage(boolean beijingLineage) {
 		this.beijingLineage = beijingLineage;
-	}
-
-	public YesNoUnknown getTreatmentStarted() {
-		return treatmentStarted;
-	}
-
-	public void setTreatmentStarted(YesNoUnknown treatmentStarted) {
-		this.treatmentStarted = treatmentStarted;
-	}
-
-	public boolean isTreatmentNotApplicable() {
-		return treatmentNotApplicable;
-	}
-
-	public void setTreatmentNotApplicable(boolean treatmentNotApplicable) {
-		this.treatmentNotApplicable = treatmentNotApplicable;
-	}
-
-	public Date getTreatmentStartDate() {
-		return treatmentStartDate;
-	}
-
-	public void setTreatmentStartDate(Date treatmentStartDate) {
-		this.treatmentStartDate = treatmentStartDate;
 	}
 }

--- a/sormas-api/src/main/resources/captions.properties
+++ b/sormas-api/src/main/resources/captions.properties
@@ -3648,6 +3648,7 @@ Notification.editNotification = Edit Notification
 Notification.viewNotification = View Notification
 Notification.notificationTypeExternal = External notification
 Notification.notificationTypePhone = Phone notification
+Notification.notifierInformation = Notifier information
 
 # Diagnosis Criteria Lab Test Details
 diagnosisCriteriaDetailTestResult = Result

--- a/sormas-api/src/main/resources/strings.properties
+++ b/sormas-api/src/main/resources/strings.properties
@@ -1983,6 +1983,8 @@ infoSystemConfigurationValueDescriptionSmsAuthSecret=Secret for SMS authenticati
 
 notificationCannotCreate=Cannot Create Or Edit Notification
 notificationCreationNotAllowedWithoutSurveillanceReport=Notifier creation or modification is not allowed when a surveillance report already exists for this case.
+notificationNotificationDateInformation=This date is automatically set based on when the notifier is created or modified.
+notificationDiagnosisDateInformation=Diagnostic date is only available when editing surveillance reports, not when editing notifiers.
 
 promptEpipulseExportDateFrom = Date from...
 promptEpipulseExportDateTo = Date to...

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/Case.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/Case.java
@@ -255,6 +255,10 @@ public class Case extends CoreAdo implements IsCase, SormasToSormasShareable, Ha
 	public static final String RADIOGRAPHY_COMPATIBILITY = "radiographyCompatibility";
 	public static final String OTHER_DIAGNOSTIC_CRITERIA = "otherDiagnosticCriteria";
 
+	public static final String TREATMENT_STARTED = "treatmentStarted";
+	public static final String TREATMENT_NOT_APPLICABLE = "treatmentNotApplicable";
+	public static final String TREATMENT_START_DATE = "treatmentStartDate";
+
 	private Person person;
 	private String description;
 	private Disease disease;
@@ -282,6 +286,9 @@ public class Case extends CoreAdo implements IsCase, SormasToSormasShareable, Ha
 	private Hospitalization hospitalization;
 	private EpiData epiData;
 	private Therapy therapy;
+	private YesNoUnknown treatmentStarted;
+	private boolean treatmentNotApplicable;
+	private Date treatmentStartDate;
 	private ClinicalCourse clinicalCourse;
 	private MaternalHistory maternalHistory;
 	private PortHealthInfo portHealthInfo;
@@ -1867,5 +1874,33 @@ public class Case extends CoreAdo implements IsCase, SormasToSormasShareable, Ha
 
 	public void setOtherDiagnosticCriteria(String otherDiagnosticCriteria) {
 		this.otherDiagnosticCriteria = otherDiagnosticCriteria;
+	}
+
+	@Column
+	@Enumerated(EnumType.STRING)
+	public YesNoUnknown getTreatmentStarted() {
+		return treatmentStarted;
+	}
+
+	public void setTreatmentStarted(YesNoUnknown treatmentStarted) {
+		this.treatmentStarted = treatmentStarted;
+	}
+
+	@Column
+	public boolean isTreatmentNotApplicable() {
+		return treatmentNotApplicable;
+	}
+
+	public void setTreatmentNotApplicable(boolean treatmentNotApplicable) {
+		this.treatmentNotApplicable = treatmentNotApplicable;
+	}
+
+	@Temporal(TemporalType.TIMESTAMP)
+	public Date getTreatmentStartDate() {
+		return treatmentStartDate;
+	}
+
+	public void setTreatmentStartDate(Date treatmentStartDate) {
+		this.treatmentStartDate = treatmentStartDate;
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
@@ -3228,6 +3228,10 @@ public class CaseFacadeEjb extends AbstractCoreFacadeEjb<Case, CaseDataDto, Case
 		target.setRadiographyCompatibility(source.getRadiographyCompatibility());
 		target.setOtherDiagnosticCriteria(source.getOtherDiagnosticCriteria());
 
+		target.setTreatmentStarted(source.getTreatmentStarted());
+		target.setTreatmentNotApplicable(source.isTreatmentNotApplicable());
+		target.setTreatmentStartDate(source.getTreatmentStartDate());
+
 		return target;
 	}
 
@@ -3438,6 +3442,10 @@ public class CaseFacadeEjb extends AbstractCoreFacadeEjb<Case, CaseDataDto, Case
 
 		target.setRadiographyCompatibility(source.getRadiographyCompatibility());
 		target.setOtherDiagnosticCriteria(source.getOtherDiagnosticCriteria());
+
+		target.setTreatmentStarted(source.getTreatmentStarted());
+		target.setTreatmentNotApplicable(source.isTreatmentNotApplicable());
+		target.setTreatmentStartDate(source.getTreatmentStartDate());
 
 		return target;
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/Therapy.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/Therapy.java
@@ -1,18 +1,9 @@
 package de.symeda.sormas.backend.therapy;
 
-
-import java.util.Date;
-
 import javax.persistence.CascadeType;
-import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.OneToOne;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
 
-import de.symeda.sormas.api.utils.YesNoUnknown;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 
@@ -32,10 +23,6 @@ public class Therapy extends AbstractDomainObject {
 	private boolean mdrXdrTuberculosis;
 	private boolean beijingLineage;
 	private Case caze;
-
-	private YesNoUnknown treatmentStarted;
-	private boolean treatmentNotApplicable;
-	private Date treatmentStartDate;
 
 	@OneToOne(cascade = CascadeType.ALL, mappedBy = Case.THERAPY)
 	public Case getCaze() {
@@ -68,33 +55,5 @@ public class Therapy extends AbstractDomainObject {
 
 	public void setBeijingLineage(boolean beijingLineage) {
 		this.beijingLineage = beijingLineage;
-	}
-
-	@Column
-	@Enumerated(EnumType.STRING)
-	public YesNoUnknown getTreatmentStarted() {
-		return treatmentStarted;
-	}
-
-	public void setTreatmentStarted(YesNoUnknown treatmentStarted) {
-		this.treatmentStarted = treatmentStarted;
-	}
-
-	@Column
-	public boolean isTreatmentNotApplicable() {
-		return treatmentNotApplicable;
-	}
-
-	public void setTreatmentNotApplicable(boolean treatmentNotApplicable) {
-		this.treatmentNotApplicable = treatmentNotApplicable;
-	}
-
-	@Temporal(TemporalType.TIMESTAMP)
-	public Date getTreatmentStartDate() {
-		return treatmentStartDate;
-	}
-
-	public void setTreatmentStartDate(Date treatmentStartDate) {
-		this.treatmentStartDate = treatmentStartDate;
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/TherapyFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/TherapyFacadeEjb.java
@@ -34,9 +34,6 @@ public class TherapyFacadeEjb implements TherapyFacade {
 		target.setDirectlyObservedTreatment(source.isDirectlyObservedTreatment());
 		target.setMdrXdrTuberculosis(source.isMdrXdrTuberculosis());
 		target.setBeijingLineage(source.isBeijingLineage());
-		target.setTreatmentStarted(source.getTreatmentStarted());
-		target.setTreatmentNotApplicable(source.isTreatmentNotApplicable());
-		target.setTreatmentStartDate(source.getTreatmentStartDate());		
 
 		return target;
 	}
@@ -54,9 +51,6 @@ public class TherapyFacadeEjb implements TherapyFacade {
 		entity.setDirectlyObservedTreatment(source.isDirectlyObservedTreatment());
 		entity.setMdrXdrTuberculosis(source.isMdrXdrTuberculosis());
 		entity.setBeijingLineage(source.isBeijingLineage());
-		entity.setTreatmentStarted(source.getTreatmentStarted());
-		entity.setTreatmentNotApplicable(source.isTreatmentNotApplicable());
-		entity.setTreatmentStartDate(source.getTreatmentStartDate());
 
 		return entity;
 	}

--- a/sormas-backend/src/main/resources/sql/sormas_schema.sql
+++ b/sormas-backend/src/main/resources/sql/sormas_schema.sql
@@ -15062,4 +15062,34 @@ ALTER TABLE testreport_history ADD COLUMN serotype character varying(255);
 ALTER TABLE testreport_history ADD COLUMN straincallstatus character varying(255);
 
 INSERT INTO schema_version (version_number, comment) VALUES (602, 'External message additional fields');
+
+-- Move treatment fields from therapy to cases #13775
+
+-- Add new columns to cases table
+ALTER TABLE cases ADD COLUMN treatmentstarted varchar(255);
+ALTER TABLE cases ADD COLUMN treatmentnotapplicable boolean DEFAULT false;
+ALTER TABLE cases ADD COLUMN treatmentstartdate timestamp;
+ALTER TABLE cases_history ADD COLUMN treatmentstarted varchar(255);
+ALTER TABLE cases_history ADD COLUMN treatmentnotapplicable boolean DEFAULT false;
+ALTER TABLE cases_history ADD COLUMN treatmentstartdate timestamp;
+-- Migrate data from therapy to cases
+UPDATE cases c
+SET treatmentstarted = t.treatmentstarted,
+    treatmentnotapplicable = t.treatmentnotapplicable,
+    treatmentstartdate = t.treatmentstartdate
+FROM therapy t
+WHERE c.therapy_id = t.id
+  AND (t.treatmentstarted IS NOT NULL 
+       OR t.treatmentnotapplicable IS NOT NULL 
+       OR t.treatmentstartdate IS NOT NULL);
+-- Drop columns from therapy table
+ALTER TABLE therapy DROP COLUMN treatmentstarted;
+ALTER TABLE therapy DROP COLUMN treatmentnotapplicable;
+ALTER TABLE therapy DROP COLUMN treatmentstartdate;
+ALTER TABLE therapy_history DROP COLUMN treatmentstarted;
+ALTER TABLE therapy_history DROP COLUMN treatmentnotapplicable;
+ALTER TABLE therapy_history DROP COLUMN treatmentstartdate;
+
+INSERT INTO schema_version (version_number, comment) VALUES (603, 'Move treatment fields from therapy to cases');
+
 -- *** Insert new sql commands BEFORE this line. Remember to always consider _history tables. ***

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierForm.java
@@ -19,6 +19,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 
 import com.vaadin.data.provider.DataProvider;
+import com.vaadin.server.UserError;
 import com.vaadin.ui.DateField;
 import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.Label;
@@ -28,11 +29,14 @@ import com.vaadin.ui.TextField;
 import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.themes.ValoTheme;
 
+import de.symeda.sormas.api.caze.CaseDataDto;
 import de.symeda.sormas.api.i18n.Captions;
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.i18n.Strings;
+import de.symeda.sormas.api.i18n.Validations;
+import de.symeda.sormas.api.location.LocationDto;
+import de.symeda.sormas.api.person.PersonDto;
 import de.symeda.sormas.api.person.notifier.NotifierDto;
-import de.symeda.sormas.api.therapy.TherapyDto;
 import de.symeda.sormas.api.utils.YesNoUnknown;
 import de.symeda.sormas.ui.utils.CssStyles;
 
@@ -61,7 +65,7 @@ public class CaseNotifierForm extends VerticalLayout {
 
     // Data objects
     private NotifierDto notifier;
-    private TherapyDto therapy;
+    private CaseDataDto caze;
 
     /**
      * Creates a new notifier form.
@@ -77,10 +81,10 @@ public class CaseNotifierForm extends VerticalLayout {
     /**
      * Creates a new notifier form with initial data.
      */
-    public CaseNotifierForm(NotifierDto notifier, TherapyDto therapy) {
+    public CaseNotifierForm(NotifierDto notifier, CaseDataDto caze) {
         this();
         this.notifier = notifier;
-        this.therapy = therapy;
+        this.caze = caze;
         populateFields();
     }
 
@@ -98,11 +102,11 @@ public class CaseNotifierForm extends VerticalLayout {
         nameLayout.setSpacing(true);
         nameLayout.setWidth(100, Unit.PERCENTAGE);
 
-        firstNameField = new TextField(I18nProperties.getPrefixCaption("Person", NotifierDto.FIRST_NAME));
+        firstNameField = new TextField(I18nProperties.getPrefixCaption(PersonDto.I18N_PREFIX, NotifierDto.FIRST_NAME));
         firstNameField.setRequiredIndicatorVisible(true);
         firstNameField.setWidth(100, Unit.PERCENTAGE);
 
-        lastNameField = new TextField(I18nProperties.getPrefixCaption("Person", NotifierDto.LAST_NAME));
+        lastNameField = new TextField(I18nProperties.getPrefixCaption(PersonDto.I18N_PREFIX, NotifierDto.LAST_NAME));
         lastNameField.setRequiredIndicatorVisible(true);
         lastNameField.setWidth(100, Unit.PERCENTAGE);
 
@@ -127,10 +131,10 @@ public class CaseNotifierForm extends VerticalLayout {
         contactLayout.setSpacing(true);
         contactLayout.setWidth(100, Unit.PERCENTAGE);
 
-        phoneField = new TextField(I18nProperties.getPrefixCaption("Person", NotifierDto.PHONE));
+        phoneField = new TextField(I18nProperties.getPrefixCaption(PersonDto.I18N_PREFIX, NotifierDto.PHONE));
         phoneField.setWidth(100, Unit.PERCENTAGE);
 
-        emailField = new TextField(I18nProperties.getPrefixCaption("Person", NotifierDto.EMAIL));
+        emailField = new TextField(I18nProperties.getPrefixCaption(PersonDto.I18N_PREFIX, NotifierDto.EMAIL));
         emailField.setWidth(100, Unit.PERCENTAGE);
 
         contactLayout.addComponents(phoneField, emailField);
@@ -139,13 +143,13 @@ public class CaseNotifierForm extends VerticalLayout {
         addComponent(contactLayout);
 
         // Address
-        addressField = new TextArea(I18nProperties.getPrefixCaption("Location", NotifierDto.ADDRESS));
+        addressField = new TextArea(I18nProperties.getPrefixCaption(LocationDto.I18N_PREFIX, NotifierDto.ADDRESS));
         addressField.setRows(3);
         addressField.setWidth(100, Unit.PERCENTAGE);
         addComponent(addressField);
 
         // Notification Dates Section
-        Label datesLabel = new Label("Notifier Information");
+        Label datesLabel = new Label(I18nProperties.getCaption(Captions.Notification_notifierInformation));
         CssStyles.style(datesLabel, CssStyles.LABEL_BOLD, CssStyles.LABEL_BOTTOM_LINE);
         addComponent(datesLabel);
 
@@ -157,12 +161,12 @@ public class CaseNotifierForm extends VerticalLayout {
         notificationDateField = new DateField(I18nProperties.getCaption(Captions.Notification_dateOfNotification));
         notificationDateField.setWidth(100, Unit.PERCENTAGE);
         notificationDateField.setEnabled(false); // Read-only as it's automatically set
-        notificationDateField.setDescription("This date is automatically set based on when the notifier is created or modified");
+        notificationDateField.setDescription(I18nProperties.getString(Strings.notificationNotificationDateInformation));
 
         diagnosticDateField = new DateField(I18nProperties.getCaption(Captions.SurveillanceReport_dateOfDiagnosis));
         diagnosticDateField.setWidth(100, Unit.PERCENTAGE);
         diagnosticDateField.setEnabled(false); // Disabled as it's only available in surveillance report context
-        diagnosticDateField.setDescription("Diagnostic date is only available when editing surveillance reports, not when editing notifiers");
+        diagnosticDateField.setDescription(I18nProperties.getString(Strings.notificationDiagnosisDateInformation));
 
         dateLayout.addComponents(notificationDateField, diagnosticDateField);
         dateLayout.setExpandRatio(notificationDateField, 1);
@@ -235,16 +239,15 @@ public class CaseNotifierForm extends VerticalLayout {
 
         treatmentGroup.clear();
 
-        if (therapy != null) {
-            if (therapy.isTreatmentNotApplicable()) {
-                treatmentGroup.setValue(TreatmentOption.NOT_APPLICABLE);
-            } else {
-                final YesNoUnknown treatmentStarted = therapy.getTreatmentStarted();
-                if (treatmentStarted != null) {
-                    treatmentGroup.setValue(TreatmentOption.forValue(treatmentStarted));
-                }
+        if (caze.isTreatmentNotApplicable()) {
+            treatmentGroup.setValue(TreatmentOption.NOT_APPLICABLE);
+        } else {
+            final YesNoUnknown treatmentStarted = caze.getTreatmentStarted();
+            if (treatmentStarted != null) {
+                treatmentGroup.setValue(TreatmentOption.forValue(treatmentStarted));
             }
         }
+
     }
 
     /**
@@ -300,21 +303,21 @@ public class CaseNotifierForm extends VerticalLayout {
         boolean valid = true;
 
         if (firstNameField.getValue() == null || firstNameField.getValue().trim().isEmpty()) {
-            firstNameField.setComponentError(new com.vaadin.server.UserError("Required field"));
+            firstNameField.setComponentError(new UserError(I18nProperties.getValidationError(Validations.requiredField)));
             valid = false;
         } else {
             firstNameField.setComponentError(null);
         }
 
         if (lastNameField.getValue() == null || lastNameField.getValue().trim().isEmpty()) {
-            lastNameField.setComponentError(new com.vaadin.server.UserError("Required field"));
+            lastNameField.setComponentError(new UserError(I18nProperties.getValidationError(Validations.requiredField)));
             valid = false;
         } else {
             lastNameField.setComponentError(null);
         }
 
         if (registrationNumberField.getValue() == null || registrationNumberField.getValue().trim().isEmpty()) {
-            registrationNumberField.setComponentError(new com.vaadin.server.UserError("Required field"));
+            registrationNumberField.setComponentError(new UserError(I18nProperties.getValidationError(Validations.requiredField)));
             valid = false;
         } else {
             registrationNumberField.setComponentError(null);

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierForm.java
@@ -239,12 +239,14 @@ public class CaseNotifierForm extends VerticalLayout {
 
         treatmentGroup.clear();
 
-        if (caze.isTreatmentNotApplicable()) {
-            treatmentGroup.setValue(TreatmentOption.NOT_APPLICABLE);
-        } else {
-            final YesNoUnknown treatmentStarted = caze.getTreatmentStarted();
-            if (treatmentStarted != null) {
-                treatmentGroup.setValue(TreatmentOption.forValue(treatmentStarted));
+        if (caze != null) {
+            if (caze.isTreatmentNotApplicable()) {
+                treatmentGroup.setValue(TreatmentOption.NOT_APPLICABLE);
+            } else {
+                final YesNoUnknown treatmentStarted = caze.getTreatmentStarted();
+                if (treatmentStarted != null) {
+                    treatmentGroup.setValue(TreatmentOption.forValue(treatmentStarted));
+                }
             }
         }
 
@@ -291,8 +293,9 @@ public class CaseNotifierForm extends VerticalLayout {
     /**
      * Sets notifier data and populates form fields.
      */
-    public void setValue(NotifierDto notifier) {
+    public void setValue(NotifierDto notifier, CaseDataDto caze) {
         this.notifier = notifier;
+        this.caze = caze;
         populateFields();
     }
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewContent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewContent.java
@@ -32,7 +32,6 @@ import de.symeda.sormas.api.caze.surveillancereport.SurveillanceReportDto;
 import de.symeda.sormas.api.i18n.Captions;
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.person.notifier.NotifierDto;
-import de.symeda.sormas.api.therapy.TherapyDto;
 import de.symeda.sormas.api.utils.YesNoUnknown;
 import de.symeda.sormas.ui.utils.CssStyles;
 
@@ -53,8 +52,6 @@ public class CaseNotifierSideViewContent extends VerticalLayout {
     /** The oldest surveillance report associated with the case. */
     private SurveillanceReportDto oldestReport;
 
-    private TherapyDto therapy;
-
     /**
      * Creates a new case notifier side view content.
      * 
@@ -68,7 +65,6 @@ public class CaseNotifierSideViewContent extends VerticalLayout {
     public CaseNotifierSideViewContent(CaseDataDto caze, NotifierDto notifier, SurveillanceReportDto oldestReport) {
 
         this.caze = caze;
-        this.therapy = caze.getTherapy();
         this.notifier = notifier;
         this.oldestReport = oldestReport;
 
@@ -188,16 +184,12 @@ public class CaseNotifierSideViewContent extends VerticalLayout {
         treatmentGroup.setReadOnly(true);
         treatmentGroup.clear();
 
-        if (therapy == null) {
-            return treatmentGroup;
-        }
-
-        if (therapy.isTreatmentNotApplicable()) {
+        if (caze.isTreatmentNotApplicable()) {
             treatmentGroup.setValue(TreatmentOption.NOT_APPLICABLE);
             return treatmentGroup;
         }
 
-        final YesNoUnknown treatmentStarted = therapy.getTreatmentStarted();
+        final YesNoUnknown treatmentStarted = caze.getTreatmentStarted();
 
         if (treatmentStarted == null) {
             return treatmentGroup;

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
@@ -33,7 +33,6 @@ import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.i18n.Strings;
 import de.symeda.sormas.api.person.notifier.NotifierDto;
 import de.symeda.sormas.api.person.notifier.NotifierReferenceDto;
-import de.symeda.sormas.api.therapy.TherapyDto;
 import de.symeda.sormas.api.utils.YesNoUnknown;
 import de.symeda.sormas.ui.utils.CommitDiscardWrapperComponent;
 import de.symeda.sormas.ui.utils.VaadinUiUtil;
@@ -114,7 +113,7 @@ public class CaseNotifierSideViewController {
         }
 
         NotifierDto newNotifier = new NotifierDto();
-        
+
         openEditWindow(caze, newNotifier, I18nProperties.getCaption(Captions.Notification_createNotification), callback, true);
     }
 
@@ -145,7 +144,6 @@ public class CaseNotifierSideViewController {
 
         // We only edit the current version
         NotifierDto notifier = FacadeProvider.getNotifierFacade().getByUuid(caze.getNotifier().getUuid());
-        TherapyDto therapy = caze.getTherapy();
 
         openEditWindow(
             caze,
@@ -196,7 +194,7 @@ public class CaseNotifierSideViewController {
         final Window window = VaadinUiUtil.showModalPopupWindow(editView, title);
 
         if (isEditAllowed) {
-            editView.setPreCommitListener((cb) -> {
+            editView.setPreCommitListener(cb -> {
                 if (!notifierForm.isValid()) {
                     // Form validation failed - errors are already shown on the form
                     return;

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
@@ -114,9 +114,8 @@ public class CaseNotifierSideViewController {
         }
 
         NotifierDto newNotifier = new NotifierDto();
-        TherapyDto therapy = caze.getTherapy();
-
-        openEditWindow(caze, newNotifier, therapy, I18nProperties.getCaption(Captions.Notification_createNotification), false, callback, true);
+        
+        openEditWindow(caze, newNotifier, I18nProperties.getCaption(Captions.Notification_createNotification), callback, true);
     }
 
     /**
@@ -151,11 +150,9 @@ public class CaseNotifierSideViewController {
         openEditWindow(
             caze,
             notifier,
-            therapy,
             isEditAllowed
                 ? I18nProperties.getCaption(Captions.Notification_editNotification)
                 : I18nProperties.getCaption(Captions.Notification_viewNotification),
-            true,
             callback,
             isEditAllowed);
     }
@@ -190,16 +187,9 @@ public class CaseNotifierSideViewController {
      * @param isEditAllowed
      *            whether editing is allowed
      */
-    private void openEditWindow(
-        CaseDataDto caze,
-        NotifierDto notifier,
-        TherapyDto therapy,
-        String title,
-        boolean canDelete,
-        Runnable callback,
-        boolean isEditAllowed) {
+    private void openEditWindow(CaseDataDto caze, NotifierDto notifier, String title, Runnable callback, boolean isEditAllowed) {
 
-        final CaseNotifierForm notifierForm = new CaseNotifierForm(notifier, therapy);
+        final CaseNotifierForm notifierForm = new CaseNotifierForm(notifier, caze);
 
         final CommitDiscardWrapperComponent<CaseNotifierForm> editView = new CommitDiscardWrapperComponent<>(notifierForm, true);
 
@@ -272,43 +262,35 @@ public class CaseNotifierSideViewController {
             return;
         }
 
-        TherapyDto therapy = caze.getTherapy();
-
-        if (therapy == null) {
-            therapy = TherapyDto.build();
-        }
-
         if (selectedOption.equals(TreatmentOption.YES)) {
-            therapy.setTreatmentStarted(YesNoUnknown.YES);
-            therapy.setTreatmentNotApplicable(false);
-            if (therapy.getTreatmentStartDate() == null) {
-                therapy.setTreatmentStartDate(new java.util.Date());
+            caze.setTreatmentStarted(YesNoUnknown.YES);
+            caze.setTreatmentNotApplicable(false);
+            if (caze.getTreatmentStartDate() == null) {
+                caze.setTreatmentStartDate(new java.util.Date());
             }
             return;
         }
 
         if (selectedOption.equals(TreatmentOption.NO)) {
-            therapy.setTreatmentStarted(YesNoUnknown.NO);
-            therapy.setTreatmentNotApplicable(false);
-            therapy.setTreatmentStartDate(null);
+            caze.setTreatmentStarted(YesNoUnknown.NO);
+            caze.setTreatmentNotApplicable(false);
+            caze.setTreatmentStartDate(null);
             return;
         }
 
         if (selectedOption.equals(TreatmentOption.NOT_APPLICABLE)) {
-            therapy.setTreatmentNotApplicable(true);
-            therapy.setTreatmentStarted(null);
-            therapy.setTreatmentStartDate(null);
+            caze.setTreatmentNotApplicable(true);
+            caze.setTreatmentStarted(null);
+            caze.setTreatmentStartDate(null);
             return;
         }
 
         if (selectedOption.equals(TreatmentOption.UNKNOWN)) {
-            therapy.setTreatmentStarted(YesNoUnknown.UNKNOWN);
-            therapy.setTreatmentNotApplicable(false);
-            therapy.setTreatmentStartDate(null);
-            return;
+            caze.setTreatmentStarted(YesNoUnknown.UNKNOWN);
+            caze.setTreatmentNotApplicable(false);
+            caze.setTreatmentStartDate(null);
         }
 
-        caze.setTherapy(therapy);
     }
 
     /**


### PR DESCRIPTION
Fixes #13775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Treatment-related fields consolidated from therapy records into case records, simplifying data model and persistence.

* **New Features**
  * Notifier forms and side views now read and update treatment data at the case level so notifier edits apply directly to case treatment state.
  * External message processing now populates treatment fields on cases.

* **Documentation**
  * Added notification and diagnostic date labels and informational messages.

* **Chores**
  * Database migration added to move treatment data into cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->