### PR TITLE
#13751 - Diagnosis date determined based on surveillance report

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/processing/AbstractMessageProcessingFlowBase.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/processing/AbstractMessageProcessingFlowBase.java
@@ -662,6 +662,7 @@ public abstract class AbstractMessageProcessingFlowBase extends AbstractProcessi
             CaseDataDto caze = result.getData().getCase();
             if (caze != null) {
                 surveillanceReport = createSurveillanceReport(externalMessage, caze);
+                updateSurveillanceReportAdditionalData(surveillanceReport, externalMessage, caze);
                 getExternalMessageProcessingFacade().saveSurveillanceReport(surveillanceReport);
             }
             markExternalMessageAsProcessed(externalMessage, result, surveillanceReport);
@@ -688,6 +689,20 @@ public abstract class AbstractMessageProcessingFlowBase extends AbstractProcessi
         surveillanceReport.setExternalId(externalMessage.getReportMessageId());
         setSurvReportingType(surveillanceReport, externalMessage);
         return surveillanceReport;
+    }
+
+    /** 
+     * Updates the additional data of the surveillance report.
+     * 
+     * @param surveillanceReport
+     *            the surveillance report
+     * @param externalMessage
+     *            the external message
+     * @param caze
+     *            the case
+     */
+    protected void updateSurveillanceReportAdditionalData(SurveillanceReportDto surveillanceReport, ExternalMessageDto externalMessage, CaseDataDto caze) {
+        surveillanceReport.setDateOfDiagnosis(externalMessage.getDiagnosticDate());
     }
 
     /**

--- a/sormas-backend/src/main/resources/sql/sormas_schema.sql
+++ b/sormas-backend/src/main/resources/sql/sormas_schema.sql
@@ -15062,4 +15062,16 @@ ALTER TABLE testreport_history ADD COLUMN serotype character varying(255);
 ALTER TABLE testreport_history ADD COLUMN straincallstatus character varying(255);
 
 INSERT INTO schema_version (version_number, comment) VALUES (602, 'External message additional fields');
+
+-- Missing date of diagnosis in surveillance reports #13751
+
+UPDATE surveillancereports sr
+SET dateofdiagnosis = em.diagnosticdate
+FROM externalmessage em
+WHERE em.surveillancereport_id = sr.id
+  AND em.diagnosticdate IS NOT NULL
+  AND sr.dateofdiagnosis IS NULL;
+
+INSERT INTO schema_version (version_number, comment) VALUES (603, 'Update surveillance report diagnosis date');
+
 -- *** Insert new sql commands BEFORE this line. Remember to always consider _history tables. ***

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewContent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewContent.java
@@ -16,6 +16,7 @@
 package de.symeda.sormas.ui.caze.notifier;
 
 import java.time.ZoneId;
+import java.util.Date;
 import java.util.Locale;
 
 import com.vaadin.data.provider.DataProvider;
@@ -28,7 +29,6 @@ import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.themes.ValoTheme;
 
 import de.symeda.sormas.api.caze.CaseDataDto;
-import de.symeda.sormas.api.caze.surveillancereport.SurveillanceReportDto;
 import de.symeda.sormas.api.i18n.Captions;
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.person.notifier.NotifierDto;
@@ -50,8 +50,11 @@ public class CaseNotifierSideViewContent extends VerticalLayout {
     /** The notifier details. */
     private NotifierDto notifier;
 
-    /** The oldest surveillance report associated with the case. */
-    private SurveillanceReportDto oldestReport;
+    /** The date of diagnosis. */
+    private Date dateOfDiagnosis;
+
+    /** The notification date. */
+    private Date notificationDate;
 
     private TherapyDto therapy;
 
@@ -65,12 +68,13 @@ public class CaseNotifierSideViewContent extends VerticalLayout {
      * @param oldestReport
      *            the oldest surveillance report for the case
      */
-    public CaseNotifierSideViewContent(CaseDataDto caze, NotifierDto notifier, SurveillanceReportDto oldestReport) {
+    public CaseNotifierSideViewContent(CaseDataDto caze, NotifierDto notifier, Date dateOfDiagnosis, Date notificationDate) {
 
         this.caze = caze;
         this.therapy = caze.getTherapy();
         this.notifier = notifier;
-        this.oldestReport = oldestReport;
+        this.dateOfDiagnosis = dateOfDiagnosis;
+        this.notificationDate = notificationDate;
 
         setStyleName("case-notifier-side-view");
         setMargin(false);
@@ -118,20 +122,18 @@ public class CaseNotifierSideViewContent extends VerticalLayout {
 
         // Date of notification
         DateField notificationDateField = new DateField(I18nProperties.getCaption(Captions.Notification_dateOfNotification));
-        notificationDateField.setValue(
-            oldestReport == null
-                ? notifier.getChangeDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()
-                : oldestReport.getReportDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
+        if (notificationDate != null) {
+            notificationDateField.setValue(notificationDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
+        } else {
+            notificationDateField.setValue(notifier.getChangeDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
+        }
         notificationDateField.setReadOnly(true);
 
         // Date of diagnostic
         DateField diagnosticDateField = new DateField(I18nProperties.getCaption(Captions.SurveillanceReport_dateOfDiagnosis));
-        diagnosticDateField.setValue(
-            oldestReport == null
-                ? null
-                : oldestReport.getDateOfDiagnosis() == null
-                    ? null
-                    : oldestReport.getDateOfDiagnosis().toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
+        if (dateOfDiagnosis != null) {
+            diagnosticDateField.setValue(dateOfDiagnosis.toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
+        }
         diagnosticDateField.setReadOnly(true);
 
         // Horizontal layout for date fields
@@ -163,7 +165,7 @@ public class CaseNotifierSideViewContent extends VerticalLayout {
         addComponent(spacerNotificationType);
         // Notification type
         Label notificationTypeLabel = new Label(
-            oldestReport == null
+            notificationDate == null
                 ? I18nProperties.getCaption(Captions.Notification_notificationTypePhone)
                 : I18nProperties.getCaption(Captions.Notification_notificationTypeExternal));
         CssStyles.style(notificationTypeLabel, CssStyles.BADGE);

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
@@ -61,7 +61,9 @@ public class CaseNotifierSideViewController {
         final NotifierDto notifier =
             FacadeProvider.getNotifierFacade().getByUuidAndTime(caze.getNotifier().getUuid(), caze.getNotifier().getVersionDate().toInstant());
 
-        final Date notificationDate = getOldestReport(caze) != null ? getOldestReport(caze).getReportDate() : null;
+        final SurveillanceReportDto oldestReport = getOldestReport(caze);
+
+        final Date notificationDate = oldestReport != null ? oldestReport.getReportDate() : null;
 
         // find diagno
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
@@ -19,6 +19,7 @@ import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 import com.vaadin.ui.Window;
 
@@ -53,10 +54,20 @@ public class CaseNotifierSideViewController {
      */
     public CaseNotifierSideViewContent getNotifierComponent(CaseDataDto caze) {
 
-        NotifierDto notifier =
+        if (caze == null) {
+            throw new IllegalArgumentException("Caze is null");
+        }
+
+        final NotifierDto notifier =
             FacadeProvider.getNotifierFacade().getByUuidAndTime(caze.getNotifier().getUuid(), caze.getNotifier().getVersionDate().toInstant());
 
-        return new CaseNotifierSideViewContent(caze, notifier, getOldestReport(caze));
+        final Date notificationDate = getOldestReport(caze) != null ? getOldestReport(caze).getReportDate() : null;
+
+        // find diagno
+
+        final Date dateOfDiagnosis = getOldestDiagnosisDateFromReports(caze);
+
+        return new CaseNotifierSideViewContent(caze, notifier, dateOfDiagnosis, notificationDate);
     }
 
     /**
@@ -67,10 +78,7 @@ public class CaseNotifierSideViewController {
      * @return oldest report or null if none found
      */
     public SurveillanceReportDto getOldestReport(CaseDataDto caze) {
-
-        CaseReferenceDto cazeRef = new CaseReferenceDto();
-        cazeRef.setUuid(caze.getUuid());
-        return getOldestReport(cazeRef);
+        return getOldestReport(caze.toReference());
     }
 
     /**
@@ -92,6 +100,42 @@ public class CaseNotifierSideViewController {
         return reports.stream()
             .min(Comparator.comparing(SurveillanceReportDto::getReportDate)) // Assuming getDate() returns the report date
             .orElse(null);
+    }
+
+    /**
+     * Retrieves the latest surveillance report for a case reference.
+     * 
+     * @param caze
+     *            the case reference
+     * @return latest report or null if none found
+     */
+    public SurveillanceReportDto getLatestReport(CaseReferenceDto caze) {
+
+        SurveillanceReportCriteria criteria = new SurveillanceReportCriteria();
+        criteria.caze(caze);
+        criteria.setReportingType(ReportingType.DOCTOR);
+
+        List<SurveillanceReportDto> reports = FacadeProvider.getSurveillanceReportFacade().getIndexList(criteria, null, null, null);
+
+        // Filter to get the oldest report
+        return reports.stream()
+            .max(Comparator.comparing(SurveillanceReportDto::getReportDate)) // Assuming getDate() returns the report date
+            .orElse(null);
+    }
+
+    public Date getOldestDiagnosisDateFromReports(CaseDataDto caze) {
+        return getOldestDiagnosisDateFromReports(caze.toReference());
+    }
+
+    public Date getOldestDiagnosisDateFromReports(CaseReferenceDto caze) {
+        SurveillanceReportCriteria criteria = new SurveillanceReportCriteria();
+        criteria.caze(caze);
+        criteria.setReportingType(ReportingType.DOCTOR);
+
+        List<SurveillanceReportDto> reports = FacadeProvider.getSurveillanceReportFacade().getIndexList(criteria, null, null, null);
+
+        // Retrieve the oldest diagnosis date
+        return reports.stream().map(SurveillanceReportDto::getDateOfDiagnosis).filter(Objects::nonNull).min(Comparator.naturalOrder()).orElse(null);
     }
 
     /**

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
@@ -108,27 +108,6 @@ public class CaseNotifierSideViewController {
             .orElse(null);
     }
 
-    /**
-     * Retrieves the latest surveillance report for a case reference.
-     * 
-     * @param caze
-     *            the case reference
-     * @return latest report or null if none found
-     */
-    public SurveillanceReportDto getLatestReport(CaseReferenceDto caze) {
-
-        SurveillanceReportCriteria criteria = new SurveillanceReportCriteria();
-        criteria.caze(caze);
-        criteria.setReportingType(ReportingType.DOCTOR);
-
-        List<SurveillanceReportDto> reports = FacadeProvider.getSurveillanceReportFacade().getIndexList(criteria, null, null, null);
-
-        // Filter to get the oldest report
-        return reports.stream()
-            .max(Comparator.comparing(SurveillanceReportDto::getReportDate)) // Assuming getDate() returns the report date
-            .orElse(null);
-    }
-
     public Date getOldestDiagnosisDateFromReports(CaseDataDto caze) {
         return getOldestDiagnosisDateFromReports(caze.toReference());
     }

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
@@ -58,6 +58,10 @@ public class CaseNotifierSideViewController {
             throw new IllegalArgumentException("Caze is null");
         }
 
+        if (caze.getNotifier() == null) {  
+            throw new IllegalArgumentException("Case Notifier is null");
+        }
+
         final NotifierDto notifier =
             FacadeProvider.getNotifierFacade().getByUuidAndTime(caze.getNotifier().getUuid(), caze.getNotifier().getVersionDate().toInstant());
 


### PR DESCRIPTION
Fixes #13751 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable population of diagnosis dates on surveillance reports during message processing.

* **UI**
  * Notifier panel now shows explicit diagnosis and notification dates, uses notifier change date as fallback, and handles missing dates gracefully.

* **Database**
  * Schema upgrade (v606) to backfill historical diagnosis dates into surveillance reports from related records.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->