### PR TITLE
#13754 - Changed the storage of phone notification

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/surveillancereport/ReportingType.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/surveillancereport/ReportingType.java
@@ -30,6 +30,8 @@ public enum ReportingType {
 	OWN_DETERMINATION,
 	NOT_DETERMINABLE,
 	NOT_RAISED,
+	@HideForCountriesExcept(countries = "LU")
+	PHONE_NOTIFICATION,
 	OTHER;
 
 	@Override

--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/surveillancereport/SurveillanceReportDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/surveillancereport/SurveillanceReportDto.java
@@ -33,6 +33,7 @@ import de.symeda.sormas.api.utils.DataHelper;
 import de.symeda.sormas.api.utils.DependingOnFeatureType;
 import de.symeda.sormas.api.utils.FieldConstraints;
 import de.symeda.sormas.api.utils.SensitiveData;
+import de.symeda.sormas.api.utils.YesNoUnknown;
 
 @DependingOnFeatureType(featureType = FeatureType.CASE_SURVEILANCE)
 public class SurveillanceReportDto extends SormasToSormasShareableDto {
@@ -52,6 +53,9 @@ public class SurveillanceReportDto extends SormasToSormasShareableDto {
 	public static final String FACILITY = "facility";
 	public static final String FACILITY_DETAILS = "facilityDetails";
 	public static final String NOTIFICATION_DETAILS = "notificationDetails";
+	public static final String TREATMENT_STARTED = "treatmentStarted";
+	public static final String TREATMENT_NOT_APPLICABLE = "treatmentNotApplicable";
+	public static final String TREATMENT_START_DATE = "treatmentStartDate";
 	private UserReferenceDto reportingUser;
 
 	@NotNull(message = Validations.requiredField)
@@ -79,6 +83,12 @@ public class SurveillanceReportDto extends SormasToSormasShareableDto {
 	@SensitiveData
 	@Size(max = FieldConstraints.CHARACTER_LIMIT_TEXT, message = Validations.textTooLong)
 	private String notificationDetails;
+
+	private YesNoUnknown treatmentStarted;
+
+	private boolean treatmentNotApplicable;
+
+	private Date treatmentStartDate;
 
 	private CaseReferenceDto caze;
 
@@ -180,6 +190,30 @@ public class SurveillanceReportDto extends SormasToSormasShareableDto {
 
 	public void setNotificationDetails(String notificationDetails) {
 		this.notificationDetails = notificationDetails;
+	}
+
+	public YesNoUnknown getTreatmentStarted() {
+		return treatmentStarted;
+	}
+
+	public void setTreatmentStarted(YesNoUnknown treatmentStarted) {
+		this.treatmentStarted = treatmentStarted;
+	}
+
+	public boolean isTreatmentNotApplicable() {
+		return treatmentNotApplicable;
+	}
+
+	public void setTreatmentNotApplicable(boolean treatmentNotApplicable) {
+		this.treatmentNotApplicable = treatmentNotApplicable;
+	}
+
+	public Date getTreatmentStartDate() {
+		return treatmentStartDate;
+	}
+
+	public void setTreatmentStartDate(Date treatmentStartDate) {
+		this.treatmentStartDate = treatmentStartDate;
 	}
 
 	public CaseReferenceDto getCaze() {

--- a/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/processing/AbstractMessageProcessingFlowBase.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/processing/AbstractMessageProcessingFlowBase.java
@@ -702,7 +702,7 @@ public abstract class AbstractMessageProcessingFlowBase extends AbstractProcessi
      *            the case
      */
     protected void updateSurveillanceReportAdditionalData(SurveillanceReportDto surveillanceReport, ExternalMessageDto externalMessage, CaseDataDto caze) {
-        surveillanceReport.setDateOfDiagnosis(externalMessage.getDiagnosticDate());
+        // no additional data to update for default implementation
     }
 
     /**

--- a/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/processing/doctordeclaration/AbstractDoctorDeclarationMessageProcessingFlow.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/processing/doctordeclaration/AbstractDoctorDeclarationMessageProcessingFlow.java
@@ -130,6 +130,33 @@ public abstract class AbstractDoctorDeclarationMessageProcessingFlow extends Abs
 	}
 
 	/**
+	 * Additional logic for updating the surveillance report in case of a doctor declaration.
+	 * Updates the date of diagnosis and treatment fields.
+	 * 
+	 * @param surveillanceReport
+	 *            The surveillance report to update.
+	 * @param externalMessage
+	 *            The external message containing the additional data.
+	 * @param caze
+	 *            The case containing the additional data.
+	 */
+	@Override
+	protected void updateSurveillanceReportAdditionalData(
+		SurveillanceReportDto surveillanceReport,
+		ExternalMessageDto externalMessage,
+		CaseDataDto caze) {
+		super.updateSurveillanceReportAdditionalData(surveillanceReport, externalMessage, caze);
+
+		// Make sure we update the date of diagnosis which is relevant for doctor declarations
+		surveillanceReport.setDateOfDiagnosis(externalMessage.getDiagnosticDate());
+
+		// Make sure we update the treatment fields which is relevant for doctor declarations
+		surveillanceReport.setTreatmentStarted(externalMessage.getTreatmentStarted());
+		surveillanceReport.setTreatmentStartDate(externalMessage.getTreatmentStartedDate());
+		surveillanceReport.setTreatmentNotApplicable(Boolean.TRUE.equals(externalMessage.getTreatmentNotApplicable()));
+	}
+
+	/**
 	 * Custom logic to execute after building a case.
 	 *
 	 * @param caseDto

--- a/sormas-api/src/main/resources/enum.properties
+++ b/sormas-api/src/main/resources/enum.properties
@@ -1270,6 +1270,7 @@ QuarantineType.ASYLUM_ACCOMMODATION = Asylum Accommodation
 
 # ReportingType
 ReportingType.NOT_RAISED = Not raised
+ReportingType.PHONE_NOTIFICATION = Phone notification
 ReportingType.OTHER = Other
 ReportingType.DOCTOR = Doctor
 ReportingType.LABORATORY = Laboratory

--- a/sormas-api/src/main/resources/strings.properties
+++ b/sormas-api/src/main/resources/strings.properties
@@ -1998,8 +1998,8 @@ infoSystemConfigurationValueDescriptionUseDeterminedVaccinationStatus=Use automa
 
 notificationCannotCreate=Cannot Create Or Edit Notification
 notificationCreationNotAllowedWithoutSurveillanceReport=Notifier creation or modification is not allowed when a surveillance report already exists for this case.
-notificationNotificationDateInformation=This date is automatically set based on when the notifier is created or modified.
-notificationDiagnosisDateInformation=Diagnostic date is only available when editing surveillance reports, not when editing notifiers.
+notificationNotificationDateInformation=This date is managed automatically based on the surveillance report date.
+notificationDiagnosisDateInformation=Diagnostic date is only available when editing surveillance reports.
 
 promptEpipulseExportDateFrom = Date from...
 promptEpipulseExportDateTo = Date to...

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/surveillancereport/SurveillanceReport.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/surveillancereport/SurveillanceReport.java
@@ -33,6 +33,7 @@ import javax.persistence.TemporalType;
 
 import de.symeda.sormas.api.caze.surveillancereport.ReportingType;
 import de.symeda.sormas.api.infrastructure.facility.FacilityType;
+import de.symeda.sormas.api.utils.YesNoUnknown;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.externalmessage.ExternalMessage;
@@ -61,6 +62,9 @@ public class SurveillanceReport extends AbstractDomainObject implements SormasTo
 	public static final String FACILITY = "facility";
 	public static final String FACILITY_DETAILS = "facilityDetails";
 	public static final String NOTIFICATION_DETAILS = "notificationDetails";
+	public static final String TREATMENT_STARTED = "treatmentStarted";
+	public static final String TREATMENT_NOT_APPLICABLE = "treatmentNotApplicable";
+	public static final String TREATMENT_START_DATE = "treatmentStartDate";
 	public static final String CAZE = "caze";
 	public static final String SORMAS_TO_SORMAS_ORIGIN_INFO = "sormasToSormasOriginInfo";
 	public static final String SORMAS_TO_SORMAS_SHARES = "sormasToSormasShares";
@@ -86,6 +90,12 @@ public class SurveillanceReport extends AbstractDomainObject implements SormasTo
 	private String facilityDetails;
 
 	private String notificationDetails;
+
+	private YesNoUnknown treatmentStarted;
+
+	private boolean treatmentNotApplicable;
+
+	private Date treatmentStartDate;
 
 	private Case caze;
 
@@ -193,6 +203,34 @@ public class SurveillanceReport extends AbstractDomainObject implements SormasTo
 
 	public void setNotificationDetails(String notificationDetails) {
 		this.notificationDetails = notificationDetails;
+	}
+
+	@Column
+	@Enumerated(EnumType.STRING)
+	public YesNoUnknown getTreatmentStarted() {
+		return treatmentStarted;
+	}
+
+	public void setTreatmentStarted(YesNoUnknown treatmentStarted) {
+		this.treatmentStarted = treatmentStarted;
+	}
+
+	@Column
+	public boolean isTreatmentNotApplicable() {
+		return treatmentNotApplicable;
+	}
+
+	public void setTreatmentNotApplicable(boolean treatmentNotApplicable) {
+		this.treatmentNotApplicable = treatmentNotApplicable;
+	}
+
+	@Temporal(TemporalType.TIMESTAMP)
+	public Date getTreatmentStartDate() {
+		return treatmentStartDate;
+	}
+
+	public void setTreatmentStartDate(Date treatmentStartDate) {
+		this.treatmentStartDate = treatmentStartDate;
 	}
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/surveillancereport/SurveillanceReportFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/surveillancereport/SurveillanceReportFacadeEjb.java
@@ -184,6 +184,9 @@ public class SurveillanceReportFacadeEjb
 		target.setFacility(facilityService.getByReferenceDto(source.getFacility()));
 		target.setFacilityDetails(source.getFacilityDetails());
 		target.setNotificationDetails(source.getNotificationDetails());
+		target.setTreatmentStarted(source.getTreatmentStarted());
+		target.setTreatmentNotApplicable(source.isTreatmentNotApplicable());
+		target.setTreatmentStartDate(source.getTreatmentStartDate());
 		target.setCaze(caseService.getByReferenceDto(source.getCaze()));
 
 		if (source.getSormasToSormasOriginInfo() != null) {
@@ -268,6 +271,9 @@ public class SurveillanceReportFacadeEjb
 		target.setFacility(FacilityFacadeEjb.toReferenceDto(source.getFacility()));
 		target.setFacilityDetails(source.getFacilityDetails());
 		target.setNotificationDetails(source.getNotificationDetails());
+		target.setTreatmentStarted(source.getTreatmentStarted());
+		target.setTreatmentNotApplicable(source.isTreatmentNotApplicable());
+		target.setTreatmentStartDate(source.getTreatmentStartDate());
 		target.setCaze(CaseFacadeEjb.toReferenceDto(source.getCaze()));
 
 		target.setSormasToSormasOriginInfo(SormasToSormasOriginInfoFacadeEjb.toDto(source.getSormasToSormasOriginInfo()));

--- a/sormas-backend/src/main/resources/sql/sormas_schema.sql
+++ b/sormas-backend/src/main/resources/sql/sormas_schema.sql
@@ -15243,4 +15243,16 @@ ALTER TABLE contact DROP COLUMN IF EXISTS contactproximity;
 ALTER TABLE contact_history DROP COLUMN IF EXISTS contactproximity;
 
 INSERT INTO schema_version (version_number, comment) VALUES (609, '#13711 - Change contactProximity to multi-select collection');
+
+-- #13754 - Create notification should create a Report - Case - DD
+
+ALTER TABLE surveillancereports ADD COLUMN treatmentstarted varchar(255);
+ALTER TABLE surveillancereports ADD COLUMN treatmentnotapplicable boolean DEFAULT false;
+ALTER TABLE surveillancereports ADD COLUMN treatmentstartdate timestamp;
+ALTER TABLE surveillancereports_history ADD COLUMN treatmentstarted varchar(255);
+ALTER TABLE surveillancereports_history ADD COLUMN treatmentnotapplicable boolean DEFAULT false;
+ALTER TABLE surveillancereports_history ADD COLUMN treatmentstartdate timestamp;
+
+INSERT INTO schema_version (version_number, comment) VALUES (610, '#13754 - Create notification should create a Report - Case - DD');
+
 -- *** Insert new sql commands BEFORE this line. Remember to always consider _history tables. ***

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierForm.java
@@ -29,7 +29,7 @@ import com.vaadin.ui.TextField;
 import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.themes.ValoTheme;
 
-import de.symeda.sormas.api.caze.CaseDataDto;
+import de.symeda.sormas.api.caze.surveillancereport.SurveillanceReportDto;
 import de.symeda.sormas.api.i18n.Captions;
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.i18n.Strings;
@@ -44,7 +44,7 @@ import de.symeda.sormas.ui.utils.CssStyles;
  * Form for creating and editing notifier information.
  * Provides editable fields for personal info, contact details, and treatment status.
  * 
- * Note: Only valid when no surveillance report exists.
+ * Creates or updates a surveillance report with PHONE_NOTIFICATION reporting type.
  */
 public class CaseNotifierForm extends VerticalLayout {
 
@@ -65,12 +65,12 @@ public class CaseNotifierForm extends VerticalLayout {
 
     // Data objects
     private NotifierDto notifier;
-    private CaseDataDto caze;
+    private SurveillanceReportDto surveillanceReport;
 
     /**
      * Creates a new notifier form.
      */
-    public CaseNotifierForm() {
+    protected CaseNotifierForm() {
         setStyleName("notifier-edit-form");
         setMargin(true);
         setSpacing(true);
@@ -81,10 +81,19 @@ public class CaseNotifierForm extends VerticalLayout {
     /**
      * Creates a new notifier form with initial data.
      */
-    public CaseNotifierForm(NotifierDto notifier, CaseDataDto caze) {
+    public CaseNotifierForm(NotifierDto notifier, SurveillanceReportDto surveillanceReport) {
         this();
+
+        if (notifier == null) {
+            throw new IllegalArgumentException("Notifier is null");
+        }
+
+        if (surveillanceReport == null) {
+            throw new IllegalArgumentException("SurveillanceReport is null");
+        }
+
         this.notifier = notifier;
-        this.caze = caze;
+        this.surveillanceReport = surveillanceReport;
         populateFields();
     }
 
@@ -165,8 +174,6 @@ public class CaseNotifierForm extends VerticalLayout {
 
         diagnosticDateField = new DateField(I18nProperties.getCaption(Captions.SurveillanceReport_dateOfDiagnosis));
         diagnosticDateField.setWidth(100, Unit.PERCENTAGE);
-        diagnosticDateField.setEnabled(false); // Disabled as it's only available in surveillance report context
-        diagnosticDateField.setDescription(I18nProperties.getString(Strings.notificationDiagnosisDateInformation));
 
         dateLayout.addComponents(notificationDateField, diagnosticDateField);
         dateLayout.setExpandRatio(notificationDateField, 1);
@@ -232,6 +239,11 @@ public class CaseNotifierForm extends VerticalLayout {
             } else if (notifier.getChangeDate() != null) {
                 notificationDateField.setValue(notifier.getChangeDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
             }
+
+            // Set diagnostic date if available
+            if (surveillanceReport != null && surveillanceReport.getDateOfDiagnosis() != null) {
+                diagnosticDateField.setValue(surveillanceReport.getDateOfDiagnosis().toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
+            }
         } else {
             // For new notifier, set notification date to current date
             notificationDateField.setValue(java.time.LocalDate.now());
@@ -239,14 +251,25 @@ public class CaseNotifierForm extends VerticalLayout {
 
         treatmentGroup.clear();
 
-        if (caze != null) {
-            if (caze.isTreatmentNotApplicable()) {
+        if (surveillanceReport != null) {
+            // Read treatment values from surveillance report
+            if (surveillanceReport.isTreatmentNotApplicable()) {
                 treatmentGroup.setValue(TreatmentOption.NOT_APPLICABLE);
             } else {
-                final YesNoUnknown treatmentStarted = caze.getTreatmentStarted();
+                final YesNoUnknown treatmentStarted = surveillanceReport.getTreatmentStarted();
                 if (treatmentStarted != null) {
                     treatmentGroup.setValue(TreatmentOption.forValue(treatmentStarted));
                 }
+            }
+
+            // Set notification date from report date
+            if (surveillanceReport.getReportDate() != null) {
+                notificationDateField.setValue(surveillanceReport.getReportDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
+            }
+
+            // Set diagnostic date if available
+            if (surveillanceReport.getDateOfDiagnosis() != null) {
+                diagnosticDateField.setValue(surveillanceReport.getDateOfDiagnosis().toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
             }
         }
 
@@ -276,15 +299,21 @@ public class CaseNotifierForm extends VerticalLayout {
     }
 
     /**
-     * Gets diagnostic date from form (always null in notifier context).
+     * Gets the notification date from the form.
      */
-    public LocalDate getDiagnosticDate() {
-        // Always returns null as the field is disabled in notifier context
-        return null; // diagnosticDateField.getValue();
+    public LocalDate getNotificationDate() {
+        return notificationDateField.getValue();
     }
 
     /**
-     * Gets selected treatment option from form.
+     * Gets the diagnostic date from the form.
+     */
+    public LocalDate getDiagnosticDate() {
+        return diagnosticDateField.getValue();
+    }
+
+    /**
+     * Gets the selected treatment option from the form.
      */
     public TreatmentOption getSelectedTreatmentOption() {
         return treatmentGroup.getValue();
@@ -293,9 +322,17 @@ public class CaseNotifierForm extends VerticalLayout {
     /**
      * Sets notifier data and populates form fields.
      */
-    public void setValue(NotifierDto notifier, CaseDataDto caze) {
+    public void setValue(NotifierDto notifier, SurveillanceReportDto surveillanceReport) {
+        if (notifier == null) {
+            throw new IllegalArgumentException("Notifier is null");
+        }
+
+        if (surveillanceReport == null) {
+            throw new IllegalArgumentException("SurveillanceReport is null");
+        }
+
         this.notifier = notifier;
-        this.caze = caze;
+        this.surveillanceReport = surveillanceReport;
         populateFields();
     }
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewComponent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewComponent.java
@@ -62,7 +62,7 @@ public class CaseNotifierSideViewComponent extends SideComponent {
 		setMargin(false);
 		setSpacing(false);
 
-		if (hasNoNotificationReports || !hasNotifier) { // if we do not have any relevant notifications or no notifier add the create button
+		if (hasNoNotificationReports || (!hasNotifier && !hasPhoneNotification)) { // if we do not have any relevant notifications or no notifier add the create button
 			addComponent(new Label(I18nProperties.getCaption(Captions.Notification_noNotification)));
 			// Create a new notification button
 			Button newNotificationButton = ButtonHelper.createIconButton(Captions.Notification_createNotification, VaadinIcons.PHONE, e -> {

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewComponent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewComponent.java
@@ -22,6 +22,8 @@ import com.vaadin.ui.themes.ValoTheme;
 
 import de.symeda.sormas.api.FacadeProvider;
 import de.symeda.sormas.api.caze.CaseDataDto;
+import de.symeda.sormas.api.caze.CaseReferenceDto;
+import de.symeda.sormas.api.caze.surveillancereport.SurveillanceReportDto;
 import de.symeda.sormas.api.i18n.Captions;
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.i18n.Strings;
@@ -36,57 +38,80 @@ import de.symeda.sormas.ui.utils.components.sidecomponent.SideComponent;
 @SuppressWarnings("serial")
 public class CaseNotifierSideViewComponent extends SideComponent {
 
+	private final transient CaseNotifierSideViewController controller = ControllerProvider.getCaseNotifierSideViewController();
+
 	/**
 	 * Creates a new notifier side view component for the given case.
 	 *
-	 * @param caze the case data for which the notifier side view is displayed
+	 * @param caze
+	 *            the case data for which the notifier side view is displayed
 	 */
 	public CaseNotifierSideViewComponent(CaseDataDto caze) {
-
 		super(I18nProperties.getString(Strings.headingCaseNotifiedBy));
+
+		final CaseReferenceDto cazeRef = caze.toReference();
+
+		final SurveillanceReportDto oldestDoctorDeclarationReport = controller.getOldestDoctorDeclarationReport(cazeRef);
+		final SurveillanceReportDto phoneNotificationReport = controller.getNewestPhoneNotificationReport(cazeRef);
+
+		final boolean hasNotifier = caze.getNotifier() != null;
+		final boolean hasPhoneNotification = phoneNotificationReport != null;
+		final boolean hasNoNotificationReports = oldestDoctorDeclarationReport == null && !hasPhoneNotification;
+
 		setWidth(100, Unit.PERCENTAGE);
 		setMargin(false);
 		setSpacing(false);
 
-		if (caze.getNotifier() != null) {
-			final var component = ControllerProvider.getCaseNotifierSideViewController().getNotifierComponent(caze);
-			addComponent(component);
+		if (hasNoNotificationReports || !hasNotifier) { // if we do not have any relevant notifications or no notifier add the create button
+			addComponent(new Label(I18nProperties.getCaption(Captions.Notification_noNotification)));
+			// Create a new notification button
+			Button newNotificationButton = ButtonHelper.createIconButton(Captions.Notification_createNotification, VaadinIcons.PHONE, e -> {
+				controller.createPhoneNotification(caze, () -> {
+					// Refresh the view by navigating back to the same case
+					ControllerProvider.getCaseController().navigateToCase(caze.getUuid());
+				});
+			}, ValoTheme.BUTTON_PRIMARY);
+			addCreateButton(newNotificationButton);
 
-			final boolean hasReport = ControllerProvider.getCaseNotifierSideViewController().getOldestReport(caze) != null;
+		} else { // we have either a phone notification or a doctor declaration report
+			if (hasPhoneNotification) { // in case we have a phone notification add the component and a button to allow the user to edit it
 
-			if (hasReport) {
-				Button notificationButton = ButtonHelper.createIconButton(Captions.Notifier_notification, VaadinIcons.BOOK, e -> {
-					final var oldestReport = ControllerProvider.getCaseNotifierSideViewController().getOldestReport(caze);
-					if (oldestReport == null) {
-						return;
-					}
-					final var externalMessage = FacadeProvider.getExternalMessageFacade().getForSurveillanceReport(oldestReport.toReference());
-					if (externalMessage == null) {
-						return;
-					}
-					ControllerProvider.getExternalMessageController().showExternalMessage(externalMessage.getUuid(), false, null);
-				}, ValoTheme.BUTTON_PRIMARY);
+				// Add the component
+				final var component = controller.getNotifierComponent(caze, phoneNotificationReport);
+				addComponent(component);
 
-				addCreateButton(notificationButton);
-			} else {
+				// Show edit button when only PHONE_NOTIFICATION exists
 				Button editNotifierButton = ButtonHelper.createIconButton(Captions.edit, VaadinIcons.EDIT, e -> {
-					ControllerProvider.getCaseNotifierSideViewController().editNotifier(caze, () -> {
+					controller.editPhoneNotification(caze, () -> {
 						// Refresh the view by navigating back to the same case
 						ControllerProvider.getCaseController().navigateToCase(caze.getUuid());
 					}, true); // true = allow editing
 				}, ValoTheme.BUTTON_PRIMARY);
 
 				addCreateButton(editNotifierButton);
+			} else {
+				if (oldestDoctorDeclarationReport != null) { // in case we have a doctor declaration the component and a button to display the external message (no edit allowed in this case)
+
+					// Add the component
+					final var component = controller.getNotifierComponent(caze, oldestDoctorDeclarationReport);
+					addComponent(component);
+
+					// Show notification button for DOCTOR reports
+					Button notificationButton = ButtonHelper.createIconButton(Captions.Notifier_notification, VaadinIcons.BOOK, e -> {
+						final var oldestReport = controller.getOldestDoctorDeclarationReport(caze);
+						if (oldestReport == null) {
+							return;
+						}
+						final var externalMessage = FacadeProvider.getExternalMessageFacade().getForSurveillanceReport(oldestReport.toReference());
+						if (externalMessage == null) {
+							return;
+						}
+						ControllerProvider.getExternalMessageController().showExternalMessage(externalMessage.getUuid(), false, null);
+					}, ValoTheme.BUTTON_PRIMARY);
+
+					addCreateButton(notificationButton);
+				}
 			}
-		} else {
-			addComponent(new Label(I18nProperties.getCaption(Captions.Notification_noNotification)));
-			Button newNotificationButton = ButtonHelper.createIconButton(Captions.Notification_createNotification, VaadinIcons.PHONE, e -> {
-				ControllerProvider.getCaseNotifierSideViewController().createNotifier(caze, () -> {
-					// Refresh the view by navigating back to the same case
-					ControllerProvider.getCaseController().navigateToCase(caze.getUuid());
-				});
-			}, ValoTheme.BUTTON_PRIMARY);
-			addCreateButton(newNotificationButton);
 		}
 	}
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewContent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewContent.java
@@ -15,6 +15,7 @@
 
 package de.symeda.sormas.ui.caze.notifier;
 
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Locale;
 
@@ -111,7 +112,10 @@ public class CaseNotifierSideViewContent extends VerticalLayout {
         if (surveillanceReport != null && surveillanceReport.getReportDate() != null) {
             notificationDateField.setValue(surveillanceReport.getReportDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
         } else {
-            notificationDateField.setValue(notifier.getChangeDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
+            notificationDateField.setValue(
+                notifier.getChangeDate() != null
+                    ? notifier.getChangeDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()
+                    : LocalDate.now());
         }
         notificationDateField.setReadOnly(true);
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewContent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewContent.java
@@ -16,7 +16,6 @@
 package de.symeda.sormas.ui.caze.notifier;
 
 import java.time.ZoneId;
-import java.util.Date;
 import java.util.Locale;
 
 import com.vaadin.data.provider.DataProvider;
@@ -28,7 +27,8 @@ import com.vaadin.ui.RadioButtonGroup;
 import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.themes.ValoTheme;
 
-import de.symeda.sormas.api.caze.CaseDataDto;
+import de.symeda.sormas.api.caze.surveillancereport.ReportingType;
+import de.symeda.sormas.api.caze.surveillancereport.SurveillanceReportDto;
 import de.symeda.sormas.api.i18n.Captions;
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.person.notifier.NotifierDto;
@@ -43,34 +43,24 @@ public class CaseNotifierSideViewContent extends VerticalLayout {
 
     private static final long serialVersionUID = 1L;
 
-    /** The case data associated with the notifier. */
-    private CaseDataDto caze;
+    /** The surveillance report with treatment data. */
+    private SurveillanceReportDto surveillanceReport;
 
     /** The notifier details. */
     private NotifierDto notifier;
 
-    /** The date of diagnosis. */
-    private Date dateOfDiagnosis;
-
-    /** The notification date. */
-    private Date notificationDate;
-
     /**
      * Creates a new case notifier side view content.
      * 
-     * @param caze
-     *            the case data
+     * @param surveillanceReport
+     *            the surveillance report with treatment data and dates
      * @param notifier
      *            the notifier details
-     * @param oldestReport
-     *            the oldest surveillance report for the case
      */
-    public CaseNotifierSideViewContent(CaseDataDto caze, NotifierDto notifier, Date dateOfDiagnosis, Date notificationDate) {
+    public CaseNotifierSideViewContent(SurveillanceReportDto surveillanceReport, NotifierDto notifier) {
 
-        this.caze = caze;
+        this.surveillanceReport = surveillanceReport;
         this.notifier = notifier;
-        this.dateOfDiagnosis = dateOfDiagnosis;
-        this.notificationDate = notificationDate;
 
         setStyleName("case-notifier-side-view");
         setMargin(false);
@@ -118,8 +108,8 @@ public class CaseNotifierSideViewContent extends VerticalLayout {
 
         // Date of notification
         DateField notificationDateField = new DateField(I18nProperties.getCaption(Captions.Notification_dateOfNotification));
-        if (notificationDate != null) {
-            notificationDateField.setValue(notificationDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
+        if (surveillanceReport != null && surveillanceReport.getReportDate() != null) {
+            notificationDateField.setValue(surveillanceReport.getReportDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
         } else {
             notificationDateField.setValue(notifier.getChangeDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
         }
@@ -127,8 +117,8 @@ public class CaseNotifierSideViewContent extends VerticalLayout {
 
         // Date of diagnostic
         DateField diagnosticDateField = new DateField(I18nProperties.getCaption(Captions.SurveillanceReport_dateOfDiagnosis));
-        if (dateOfDiagnosis != null) {
-            diagnosticDateField.setValue(dateOfDiagnosis.toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
+        if (surveillanceReport != null && surveillanceReport.getDateOfDiagnosis() != null) {
+            diagnosticDateField.setValue(surveillanceReport.getDateOfDiagnosis().toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
         }
         diagnosticDateField.setReadOnly(true);
 
@@ -161,7 +151,7 @@ public class CaseNotifierSideViewContent extends VerticalLayout {
         addComponent(spacerNotificationType);
         // Notification type
         Label notificationTypeLabel = new Label(
-            notificationDate == null
+            (surveillanceReport != null && surveillanceReport.getReportingType() == ReportingType.PHONE_NOTIFICATION)
                 ? I18nProperties.getCaption(Captions.Notification_notificationTypePhone)
                 : I18nProperties.getCaption(Captions.Notification_notificationTypeExternal));
         CssStyles.style(notificationTypeLabel, CssStyles.BADGE);
@@ -186,12 +176,16 @@ public class CaseNotifierSideViewContent extends VerticalLayout {
         treatmentGroup.setReadOnly(true);
         treatmentGroup.clear();
 
-        if (caze.isTreatmentNotApplicable()) {
+        if (surveillanceReport == null) {
+            return treatmentGroup;
+        }
+
+        if (surveillanceReport.isTreatmentNotApplicable()) {
             treatmentGroup.setValue(TreatmentOption.NOT_APPLICABLE);
             return treatmentGroup;
         }
 
-        final YesNoUnknown treatmentStarted = caze.getTreatmentStarted();
+        final YesNoUnknown treatmentStarted = surveillanceReport.getTreatmentStarted();
 
         if (treatmentStarted == null) {
             return treatmentGroup;

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
@@ -101,19 +101,23 @@ public class CaseNotifierSideViewController {
     public boolean hasNoNotificationReports(CaseReferenceDto caze) {
         // Get all reports criteria
         SurveillanceReportCriteria caseCriteria = new SurveillanceReportCriteria();
-        caseCriteria.caze(caze);
-        FacadeProvider.getSurveillanceReportFacade().count(caseCriteria);
-
+        caseCriteria.caze(caze);        
         // If any reports exist, return false
         return FacadeProvider.getSurveillanceReportFacade().count(caseCriteria) == 0;
     }
 
     public boolean hasOnlyPhoneNotificationReports(CaseReferenceDto caze) {
         // Get reports with PHONE_NOTIFICATION reporting type
-        SurveillanceReportCriteria phoneCriteria = new SurveillanceReportCriteria();
+        final SurveillanceReportCriteria phoneCriteria = new SurveillanceReportCriteria();
         phoneCriteria.caze(caze);
         phoneCriteria.setReportingType(ReportingType.PHONE_NOTIFICATION);
-        return FacadeProvider.getSurveillanceReportFacade().count(phoneCriteria) == 0;
+        final long phoneRepCount = FacadeProvider.getSurveillanceReportFacade().count(phoneCriteria);
+
+        final SurveillanceReportCriteria caseCriteria = new SurveillanceReportCriteria();
+        caseCriteria.caze(caze);
+        final long caseRepCount = FacadeProvider.getSurveillanceReportFacade().count(caseCriteria);
+
+        return phoneRepCount == caseRepCount;
     }
 
     public boolean hasPhoneNotification(CaseReferenceDto caze) {
@@ -260,8 +264,8 @@ public class CaseNotifierSideViewController {
             surveillanceReport.setReportingType(ReportingType.PHONE_NOTIFICATION);
             surveillanceReport.setReportDate(new Date());
         } else {
-            // Use existing report (first one if multiple exist)
-            surveillanceReport = existingReports.get(0);
+            // Use existing report (newest one if multiple exist)
+            surveillanceReport = getNewestPhoneNotificationReport(caze);
         }
 
         final CaseNotifierForm notifierForm = new CaseNotifierForm(notifier, surveillanceReport);

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
@@ -16,11 +16,12 @@
 package de.symeda.sormas.ui.caze.notifier;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 
+import com.vaadin.ui.Button;
 import com.vaadin.ui.Window;
 
 import de.symeda.sormas.api.FacadeProvider;
@@ -31,10 +32,10 @@ import de.symeda.sormas.api.caze.surveillancereport.SurveillanceReportCriteria;
 import de.symeda.sormas.api.caze.surveillancereport.SurveillanceReportDto;
 import de.symeda.sormas.api.i18n.Captions;
 import de.symeda.sormas.api.i18n.I18nProperties;
-import de.symeda.sormas.api.i18n.Strings;
 import de.symeda.sormas.api.person.notifier.NotifierDto;
 import de.symeda.sormas.api.person.notifier.NotifierReferenceDto;
 import de.symeda.sormas.api.utils.YesNoUnknown;
+import de.symeda.sormas.ui.utils.ButtonHelper;
 import de.symeda.sormas.ui.utils.CommitDiscardWrapperComponent;
 import de.symeda.sormas.ui.utils.VaadinUiUtil;
 
@@ -51,28 +52,20 @@ public class CaseNotifierSideViewController {
      *            the case data
      * @return notifier component with associated report and treatment details
      */
-    public CaseNotifierSideViewContent getNotifierComponent(CaseDataDto caze) {
+    public CaseNotifierSideViewContent getNotifierComponent(CaseDataDto caze, SurveillanceReportDto surveillanceReport) {
 
         if (caze == null) {
             throw new IllegalArgumentException("Caze is null");
         }
 
-        if (caze.getNotifier() == null) {  
+        if (caze.getNotifier() == null) {
             throw new IllegalArgumentException("Case Notifier is null");
         }
 
         final NotifierDto notifier =
             FacadeProvider.getNotifierFacade().getByUuidAndTime(caze.getNotifier().getUuid(), caze.getNotifier().getVersionDate().toInstant());
 
-        final SurveillanceReportDto oldestReport = getOldestReport(caze);
-
-        final Date notificationDate = oldestReport != null ? oldestReport.getReportDate() : null;
-
-        // find diagno
-
-        final Date dateOfDiagnosis = getOldestDiagnosisDateFromReports(caze);
-
-        return new CaseNotifierSideViewContent(caze, notifier, dateOfDiagnosis, notificationDate);
+        return new CaseNotifierSideViewContent(surveillanceReport, notifier);
     }
 
     /**
@@ -82,8 +75,8 @@ public class CaseNotifierSideViewController {
      *            the case
      * @return oldest report or null if none found
      */
-    public SurveillanceReportDto getOldestReport(CaseDataDto caze) {
-        return getOldestReport(caze.toReference());
+    public SurveillanceReportDto getOldestDoctorDeclarationReport(CaseDataDto caze) {
+        return getOldestDoctorDeclarationReport(caze.toReference());
     }
 
     /**
@@ -93,62 +86,113 @@ public class CaseNotifierSideViewController {
      *            the case reference
      * @return oldest report or null if none found
      */
-    public SurveillanceReportDto getOldestReport(CaseReferenceDto caze) {
+    public SurveillanceReportDto getOldestDoctorDeclarationReport(CaseReferenceDto caze) {
 
-        SurveillanceReportCriteria criteria = new SurveillanceReportCriteria();
-        criteria.caze(caze);
-        criteria.setReportingType(ReportingType.DOCTOR);
-
-        List<SurveillanceReportDto> reports = FacadeProvider.getSurveillanceReportFacade().getIndexList(criteria, null, null, null);
+        // Get reports with DOCTOR reporting type
+        SurveillanceReportCriteria doctorCriteria = new SurveillanceReportCriteria();
+        doctorCriteria.caze(caze);
+        doctorCriteria.setReportingType(ReportingType.DOCTOR);
+        List<SurveillanceReportDto> doctorReports = FacadeProvider.getSurveillanceReportFacade().getIndexList(doctorCriteria, null, null, null);
 
         // Filter to get the oldest report
-        return reports.stream()
-            .min(Comparator.comparing(SurveillanceReportDto::getReportDate)) // Assuming getDate() returns the report date
-            .orElse(null);
+        return doctorReports.stream().min(Comparator.comparing(SurveillanceReportDto::getReportDate)).orElse(null);
     }
 
-    public Date getOldestDiagnosisDateFromReports(CaseDataDto caze) {
-        return getOldestDiagnosisDateFromReports(caze.toReference());
+    public boolean hasNoNotificationReports(CaseReferenceDto caze) {
+        // Get all reports criteria
+        SurveillanceReportCriteria caseCriteria = new SurveillanceReportCriteria();
+        caseCriteria.caze(caze);
+        FacadeProvider.getSurveillanceReportFacade().count(caseCriteria);
+
+        // If any reports exist, return false
+        return FacadeProvider.getSurveillanceReportFacade().count(caseCriteria) == 0;
     }
 
-    public Date getOldestDiagnosisDateFromReports(CaseReferenceDto caze) {
-        SurveillanceReportCriteria criteria = new SurveillanceReportCriteria();
-        criteria.caze(caze);
-        criteria.setReportingType(ReportingType.DOCTOR);
+    public boolean hasOnlyPhoneNotificationReports(CaseReferenceDto caze) {
+        // Get reports with PHONE_NOTIFICATION reporting type
+        SurveillanceReportCriteria phoneCriteria = new SurveillanceReportCriteria();
+        phoneCriteria.caze(caze);
+        phoneCriteria.setReportingType(ReportingType.PHONE_NOTIFICATION);
+        return FacadeProvider.getSurveillanceReportFacade().count(phoneCriteria) == 0;
+    }
 
-        List<SurveillanceReportDto> reports = FacadeProvider.getSurveillanceReportFacade().getIndexList(criteria, null, null, null);
-
-        // Retrieve the oldest diagnosis date
-        return reports.stream().map(SurveillanceReportDto::getDateOfDiagnosis).filter(Objects::nonNull).min(Comparator.naturalOrder()).orElse(null);
+    public boolean hasPhoneNotification(CaseReferenceDto caze) {
+        SurveillanceReportCriteria phoneCriteria = new SurveillanceReportCriteria();
+        phoneCriteria.caze(caze);
+        phoneCriteria.setReportingType(ReportingType.PHONE_NOTIFICATION);
+        return FacadeProvider.getSurveillanceReportFacade().count(phoneCriteria) != 0;
     }
 
     /**
-     * Opens a dialog to create a new notifier.
-     * Only allowed when no surveillance report exists for the case.
+     * Retrieves the newest PHONE_NOTIFICATION surveillance report for a case.
+     *
+     * @param caze
+     *            the case reference
+     * @return the newest PHONE_NOTIFICATION report or null if none found
+     */
+    public SurveillanceReportDto getNewestPhoneNotificationReport(CaseReferenceDto caze) {
+        SurveillanceReportCriteria criteria = new SurveillanceReportCriteria();
+        criteria.caze(caze);
+        criteria.setReportingType(ReportingType.PHONE_NOTIFICATION);
+        List<SurveillanceReportDto> phoneReports = FacadeProvider.getSurveillanceReportFacade().getIndexList(criteria, null, null, null);
+
+        return phoneReports.stream().max(Comparator.comparing(SurveillanceReportDto::getReportDate)).orElse(null);
+    }
+
+    /**
+     * Retrieves the newest PHONE_NOTIFICATION surveillance report for a case.
+     *
+     * @param caze
+     *            the case data
+     * @return the newest PHONE_NOTIFICATION report or null if none found
+     */
+    public SurveillanceReportDto getNewestPhoneNotificationReport(CaseDataDto caze) {
+        return getNewestPhoneNotificationReport(caze.toReference());
+    }
+
+    /**
+     * Opens a dialog to create a new phone notification surveillance report for a case.
+     * Creates a SurveillanceReport with PHONE_NOTIFICATION reporting type.
+     *
+     * @param caseRef
+     *            case reference
+     * @param callback
+     *            callback to run after successful save or dialog close
+     */
+    public void createPhoneNotification(CaseReferenceDto caseRef, Runnable callback) {
+        this.createPhoneNotification(FacadeProvider.getCaseFacade().getByUuid(caseRef.getUuid()), callback);
+    }
+
+    /**
+     * Opens a dialog to create a new phone notification surveillance report.
+     * Creates a SurveillanceReport with PHONE_NOTIFICATION reporting type.
      *
      * @param caze
      *            the case for which to create a notifier
      * @param callback
      *            callback to run after successful save or dialog close
      */
-    public void createNotifier(CaseDataDto caze, Runnable callback) {
-        // Check if surveillance report exists - if so, notifier creation is not allowed
-        SurveillanceReportDto oldestReport = getOldestReport(caze);
-        if (oldestReport != null) {
-            VaadinUiUtil.showSimplePopupWindow(
-                I18nProperties.getString(Strings.notificationCannotCreate),
-                I18nProperties.getString(Strings.notificationCreationNotAllowedWithoutSurveillanceReport));
-            return;
-        }
-
+    public void createPhoneNotification(CaseDataDto caze, Runnable callback) {
         NotifierDto newNotifier = new NotifierDto();
 
         openEditWindow(caze, newNotifier, I18nProperties.getCaption(Captions.Notification_createNotification), callback, true);
     }
 
     /**
-     * Opens a dialog to edit an existing notifier.
-     * Only allowed when no surveillance report exists for the case.
+     * Opens a dialog to edit an existing phone notification.
+     * Edits the phone notification surveillance report.
+     *
+     * @param caseRef
+     * @param callback
+     * @param isEditAllowed
+     */
+    public void editPhoneNotification(CaseReferenceDto caseRef, Runnable callback, boolean isEditAllowed) {
+        this.editPhoneNotification(FacadeProvider.getCaseFacade().getByUuid(caseRef.getUuid()), callback, isEditAllowed);
+    }
+
+    /**
+     * Opens a dialog to edit an existing phone notification.
+     * Edits the phone notification surveillance report.
      *
      * @param caze
      *            the case containing the notifier to edit
@@ -157,17 +201,8 @@ public class CaseNotifierSideViewController {
      * @param isEditAllowed
      *            whether editing is allowed for this user
      */
-    public void editNotifier(CaseDataDto caze, Runnable callback, boolean isEditAllowed) {
+    public void editPhoneNotification(CaseDataDto caze, Runnable callback, boolean isEditAllowed) {
         if (caze.getNotifier() == null) {
-            return;
-        }
-
-        // Check if surveillance report exists - if so, notifier editing is not allowed
-        SurveillanceReportDto oldestReport = getOldestReport(caze);
-        if (oldestReport != null && isEditAllowed) {
-            VaadinUiUtil.showSimplePopupWindow(
-                I18nProperties.getString(Strings.notificationCannotCreate),
-                I18nProperties.getString(Strings.notificationCreationNotAllowedWithoutSurveillanceReport));
             return;
         }
 
@@ -192,8 +227,8 @@ public class CaseNotifierSideViewController {
      * @param callback
      *            callback to run after dialog close
      */
-    public void viewNotifier(CaseDataDto caze, Runnable callback) {
-        editNotifier(caze, callback, false);
+    public void viewPhoneNotification(CaseDataDto caze, Runnable callback) {
+        editPhoneNotification(caze, callback, false);
     }
 
     /**
@@ -203,12 +238,8 @@ public class CaseNotifierSideViewController {
      *            the case data
      * @param notifier
      *            the notifier to edit/view
-     * @param therapy
-     *            the therapy data
      * @param title
      *            the dialog title
-     * @param canDelete
-     *            whether delete functionality should be available
      * @param callback
      *            callback to run after successful save or dialog close
      * @param isEditAllowed
@@ -216,7 +247,24 @@ public class CaseNotifierSideViewController {
      */
     private void openEditWindow(CaseDataDto caze, NotifierDto notifier, String title, Runnable callback, boolean isEditAllowed) {
 
-        final CaseNotifierForm notifierForm = new CaseNotifierForm(notifier, caze);
+        // Get or create PHONE_NOTIFICATION surveillance report
+        SurveillanceReportCriteria criteria = new SurveillanceReportCriteria();
+        criteria.caze(caze.toReference());
+        criteria.setReportingType(ReportingType.PHONE_NOTIFICATION);
+        List<SurveillanceReportDto> existingReports = FacadeProvider.getSurveillanceReportFacade().getIndexList(criteria, null, null, null);
+
+        SurveillanceReportDto surveillanceReport;
+        if (existingReports.isEmpty()) {
+            // Create new report
+            surveillanceReport = SurveillanceReportDto.build(caze.toReference(), FacadeProvider.getUserFacade().getCurrentUserAsReference());
+            surveillanceReport.setReportingType(ReportingType.PHONE_NOTIFICATION);
+            surveillanceReport.setReportDate(new Date());
+        } else {
+            // Use existing report (first one if multiple exist)
+            surveillanceReport = existingReports.get(0);
+        }
+
+        final CaseNotifierForm notifierForm = new CaseNotifierForm(notifier, surveillanceReport);
 
         final CommitDiscardWrapperComponent<CaseNotifierForm> editView = new CommitDiscardWrapperComponent<>(notifierForm, true);
 
@@ -240,17 +288,9 @@ public class CaseNotifierSideViewController {
                         FacadeProvider.getNotifierFacade().getVersionReferenceByUuidAndDate(savedNotifier.getUuid());
                     caze.setNotifier(notifierRef);
 
-                    // Handle treatment option changes
-
-                    final TreatmentOption selectedOption = notifierForm.getSelectedTreatmentOption();
-                    updateTherapyBasedOnSelection(caze, selectedOption);
-
-                    // Handle diagnostic date updates if changed
-                    final LocalDate diagnosticDate = notifierForm.getDiagnosticDate();
-                    if (diagnosticDate != null) {
-                        final Date diagnosisDate = Date.from(diagnosticDate.atStartOfDay(java.time.ZoneId.systemDefault()).toInstant());
-                        handleDiagnosticDateUpdate(caze, diagnosisDate);
-                    }
+                    // Update surveillance report with form values
+                    updateSurveillanceReportFromForm(surveillanceReport, notifierForm);
+                    FacadeProvider.getSurveillanceReportFacade().save(surveillanceReport);
 
                     FacadeProvider.getCaseFacade().save(caze);
 
@@ -262,6 +302,7 @@ public class CaseNotifierSideViewController {
             });
 
             // TODO - NotifierFacade doesn't seem to have delete functionality yet
+            // REVIEW - don't know if it is ever desired to be able to delete a phone notification
             // if (canDelete) {
             //     editView.addDeleteListener(() -> {
             //         // Delete functionality would go here
@@ -272,65 +313,61 @@ public class CaseNotifierSideViewController {
         } else {
             // For read-only mode, disable all form fields
             notifierForm.setEnabled(false);
+            
+            // Hide save and discard buttons, add a close button instead
+            editView.getCommitButton().setVisible(false);
+            editView.getDiscardButton().setVisible(false);
+            
+            Button closeButton = ButtonHelper.createButton(Captions.actionClose, e -> window.close());
+            editView.getButtonsPanel().addComponent(closeButton);
         }
     }
 
     /**
-     * Updates therapy data based on selected treatment option.
+     * Updates the surveillance report with values from the notifier form.
+     * Applies business logic for dates and treatment status.
      *
-     * @param caze
-     *            the case data containing the therapy
-     * @param selectedOption
-     *            the selected treatment option from the form
+     * @param surveillanceReport
+     *            the surveillance report to update
+     * @param notifierForm
+     *            the form containing the values
      */
-    private void updateTherapyBasedOnSelection(CaseDataDto caze, TreatmentOption selectedOption) {
-
-        if (selectedOption == null) {
-            return;
+    private void updateSurveillanceReportFromForm(SurveillanceReportDto surveillanceReport, CaseNotifierForm notifierForm) {
+        // Update report date from notification date
+        final LocalDate notificationDate = notifierForm.getNotificationDate();
+        if (notificationDate != null) {
+            surveillanceReport.setReportDate(Date.from(notificationDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
         }
 
-        if (selectedOption.equals(TreatmentOption.YES)) {
-            caze.setTreatmentStarted(YesNoUnknown.YES);
-            caze.setTreatmentNotApplicable(false);
-            if (caze.getTreatmentStartDate() == null) {
-                caze.setTreatmentStartDate(new java.util.Date());
+        // Update diagnosis date if provided
+        final LocalDate diagnosticDate = notifierForm.getDiagnosticDate();
+        if (diagnosticDate != null) {
+            surveillanceReport.setDateOfDiagnosis(Date.from(diagnosticDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+        }
+
+        // Update treatment based on selected option
+        final TreatmentOption selectedOption = notifierForm.getSelectedTreatmentOption();
+        if (selectedOption != null) {
+            if (selectedOption.equals(TreatmentOption.YES)) {
+                surveillanceReport.setTreatmentStarted(YesNoUnknown.YES);
+                surveillanceReport.setTreatmentNotApplicable(false);
+                if (surveillanceReport.getTreatmentStartDate() == null) {
+                    surveillanceReport.setTreatmentStartDate(new Date());
+                }
+            } else if (selectedOption.equals(TreatmentOption.NO)) {
+                surveillanceReport.setTreatmentStarted(YesNoUnknown.NO);
+                surveillanceReport.setTreatmentNotApplicable(false);
+                surveillanceReport.setTreatmentStartDate(null);
+            } else if (selectedOption.equals(TreatmentOption.NOT_APPLICABLE)) {
+                surveillanceReport.setTreatmentNotApplicable(true);
+                surveillanceReport.setTreatmentStarted(null);
+                surveillanceReport.setTreatmentStartDate(null);
+            } else if (selectedOption.equals(TreatmentOption.UNKNOWN)) {
+                surveillanceReport.setTreatmentStarted(YesNoUnknown.UNKNOWN);
+                surveillanceReport.setTreatmentNotApplicable(false);
+                surveillanceReport.setTreatmentStartDate(null);
             }
-            return;
         }
-
-        if (selectedOption.equals(TreatmentOption.NO)) {
-            caze.setTreatmentStarted(YesNoUnknown.NO);
-            caze.setTreatmentNotApplicable(false);
-            caze.setTreatmentStartDate(null);
-            return;
-        }
-
-        if (selectedOption.equals(TreatmentOption.NOT_APPLICABLE)) {
-            caze.setTreatmentNotApplicable(true);
-            caze.setTreatmentStarted(null);
-            caze.setTreatmentStartDate(null);
-            return;
-        }
-
-        if (selectedOption.equals(TreatmentOption.UNKNOWN)) {
-            caze.setTreatmentStarted(YesNoUnknown.UNKNOWN);
-            caze.setTreatmentNotApplicable(false);
-            caze.setTreatmentStartDate(null);
-        }
-
-    }
-
-    /**
-     * Handles diagnostic date updates from the notifier form.
-     * Placeholder for future diagnostic date handling.
-     *
-     * @param caze
-     *            the case data
-     * @param diagnosisDate
-     *            the diagnosis date from the form
-     */
-    private void handleDiagnosticDateUpdate(CaseDataDto caze, java.util.Date diagnosisDate) {
-        // TODO - Implement proper diagnostic date handling
     }
 
 }

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
@@ -95,13 +95,16 @@ public class CaseNotifierSideViewController {
         List<SurveillanceReportDto> doctorReports = FacadeProvider.getSurveillanceReportFacade().getIndexList(doctorCriteria, null, null, null);
 
         // Filter to get the oldest report
-        return doctorReports.stream().min(Comparator.comparing(SurveillanceReportDto::getReportDate)).orElse(null);
+        return doctorReports.stream()
+            .filter(r -> r.getReportDate() != null)
+            .min(Comparator.comparing(SurveillanceReportDto::getReportDate))
+            .orElse(null);
     }
 
     public boolean hasNoNotificationReports(CaseReferenceDto caze) {
         // Get all reports criteria
         SurveillanceReportCriteria caseCriteria = new SurveillanceReportCriteria();
-        caseCriteria.caze(caze);        
+        caseCriteria.caze(caze);
         // If any reports exist, return false
         return FacadeProvider.getSurveillanceReportFacade().count(caseCriteria) == 0;
     }
@@ -117,7 +120,7 @@ public class CaseNotifierSideViewController {
         caseCriteria.caze(caze);
         final long caseRepCount = FacadeProvider.getSurveillanceReportFacade().count(caseCriteria);
 
-        return phoneRepCount == caseRepCount;
+        return phoneRepCount > 0 && phoneRepCount == caseRepCount;
     }
 
     public boolean hasPhoneNotification(CaseReferenceDto caze) {
@@ -140,7 +143,10 @@ public class CaseNotifierSideViewController {
         criteria.setReportingType(ReportingType.PHONE_NOTIFICATION);
         List<SurveillanceReportDto> phoneReports = FacadeProvider.getSurveillanceReportFacade().getIndexList(criteria, null, null, null);
 
-        return phoneReports.stream().max(Comparator.comparing(SurveillanceReportDto::getReportDate)).orElse(null);
+        return phoneReports.stream()
+            .filter(r -> r.getReportDate() != null)
+            .max(Comparator.comparing(SurveillanceReportDto::getReportDate))
+            .orElse(null);
     }
 
     /**
@@ -317,11 +323,11 @@ public class CaseNotifierSideViewController {
         } else {
             // For read-only mode, disable all form fields
             notifierForm.setEnabled(false);
-            
+
             // Hide save and discard buttons, add a close button instead
             editView.getCommitButton().setVisible(false);
             editView.getDiscardButton().setVisible(false);
-            
+
             Button closeButton = ButtonHelper.createButton(Captions.actionClose, e -> window.close());
             editView.getButtonsPanel().addComponent(closeButton);
         }
@@ -339,15 +345,11 @@ public class CaseNotifierSideViewController {
     private void updateSurveillanceReportFromForm(SurveillanceReportDto surveillanceReport, CaseNotifierForm notifierForm) {
         // Update report date from notification date
         final LocalDate notificationDate = notifierForm.getNotificationDate();
-        if (notificationDate != null) {
-            surveillanceReport.setReportDate(Date.from(notificationDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
-        }
+        surveillanceReport.setReportDate(Date.from(notificationDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
 
         // Update diagnosis date if provided
         final LocalDate diagnosticDate = notifierForm.getDiagnosticDate();
-        if (diagnosticDate != null) {
-            surveillanceReport.setDateOfDiagnosis(Date.from(diagnosticDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
-        }
+        surveillanceReport.setDateOfDiagnosis(Date.from(diagnosticDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
 
         // Update treatment based on selected option
         final TreatmentOption selectedOption = notifierForm.getSelectedTreatmentOption();

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/surveillancereport/SurveillanceReportList.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/surveillancereport/SurveillanceReportList.java
@@ -54,12 +54,14 @@ import de.symeda.sormas.ui.utils.components.sidecomponent.SideComponentField;
 public class SurveillanceReportList extends PaginationList<SurveillanceReportDto> {
 
 	private final SurveillanceReportCriteria criteria = new SurveillanceReportCriteria();
+	private final CaseReferenceDto caseRef;
 	private final boolean isEditAllowed;
 	private final UserRight editRight;
 
 	public SurveillanceReportList(CaseReferenceDto caze, UserRight editRight, boolean isEditAllowed) {
 		super(5);
 		criteria.caze(caze);
+		this.caseRef = caze;
 		this.editRight = editRight;
 		this.isEditAllowed = isEditAllowed;
 	}
@@ -138,6 +140,11 @@ public class SurveillanceReportList extends PaginationList<SurveillanceReportDto
 				continue;
 			}
 
+			// Skip entry if the user doesn't have the permission to view the report
+			if (ReportingType.PHONE_NOTIFICATION.equals(report.getReportingType()) && !userHasDoctorDeclarationView) {
+				continue;
+			}
+
 			SurveillanceReportListEntry listEntry = new SurveillanceReportListEntry(report);
 
 			// Only allow editing if the user has the permission to edit the case
@@ -149,13 +156,24 @@ public class SurveillanceReportList extends PaginationList<SurveillanceReportDto
 				&& !report.isOwnershipHandedOver()
 				&& (report.getSormasToSormasOriginInfo() == null || report.getSormasToSormasOriginInfo().isOwnershipHandedOver())
 				&& ((ReportingType.LABORATORY.equals(report.getReportingType()) && userHasLaboratoryProcessing)
-					|| (ReportingType.DOCTOR.equals(report.getReportingType()) && userHasDoctorDeclarationProcessing));
+					|| (ReportingType.DOCTOR.equals(report.getReportingType()) && userHasDoctorDeclarationProcessing)
+					|| (ReportingType.PHONE_NOTIFICATION.equals(report.getReportingType()) && userHasDoctorDeclarationProcessing));
 
-			listEntry.addActionButton(
-				report.getUuid(),
-				(Button.ClickListener) event -> ControllerProvider.getSurveillanceReportController()
-					.editSurveillanceReport(listEntry.getReport(), this::reload, isEditable),
-				isEditable);
+			if (ReportingType.PHONE_NOTIFICATION.equals(report.getReportingType())) {
+				// we do not allow editing frome the side view because we cannot reload the case page
+				// phone notifications are only editable from the case page notification box
+				listEntry.addActionButton(
+					report.getUuid(),
+					(Button.ClickListener) event -> ControllerProvider.getCaseNotifierSideViewController()
+						.editPhoneNotification(caseRef, this::reload, false),
+					false);
+			} else {
+				listEntry.addActionButton(
+					report.getUuid(),
+					(Button.ClickListener) event -> ControllerProvider.getSurveillanceReportController()
+						.editSurveillanceReport(listEntry.getReport(), this::reload, isEditable),
+					isEditable);
+			}
 
 			listEntry.setEnabled(isEditable);
 


### PR DESCRIPTION
Fixes #13754 

Implement phone notification reporting functionality that allows phone notifications for cases through the use of surveillance reporting system.

What's New:
- Users are now createing phone notification reports for cases through the case notification panel
- Phone notification report can hold now additional potential fields
- Treatment information is now stored in the surveillance report
- Diagnostic dates is now recorded in the surveillance report
- Phone notifications can be viewed and edited by authorized users
- Read-only view mode displays a close button instead of save/discard options

Key Changes:
- New PHONE_NOTIFICATION reporting type added to surveillance reports
- Treatment fields added to surveillance report tracking
- Improved UI forms for creating and editing phone notifications
- Phone notifications are properly integrated into the surveillance report list
- Allows additional fields to be potentially added to phone notifications



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Phone notification" as a reporting type.
  * Surveillance reports now record treatment started, treatment start date, and treatment-not-applicable.

* **Improvements**
  * Notifier UI now manages phone notifications and doctor-declaration flows from surveillance reports.
  * Help text clarified for notification and diagnosis date handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->