### PR TITLE
#13754 - Fixed NPE when date of diagnosis is not provided

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
@@ -343,13 +343,20 @@ public class CaseNotifierSideViewController {
      *            the form containing the values
      */
     private void updateSurveillanceReportFromForm(SurveillanceReportDto surveillanceReport, CaseNotifierForm notifierForm) {
-        // Update report date from notification date
-        final LocalDate notificationDate = notifierForm.getNotificationDate() == null ? LocalDate.now() : notifierForm.getNotificationDate();
-        surveillanceReport.setReportDate(Date.from(notificationDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+
+        // Update report date from notification date if provided
+        if (notifierForm.getNotificationDate() != null) {
+            surveillanceReport.setReportDate(Date.from(notifierForm.getNotificationDate().atStartOfDay(ZoneId.systemDefault()).toInstant()));
+        } else {
+            // if no notification date is provided, use the current date as long as the report date is not set
+            if (surveillanceReport.getReportDate() == null) {
+                surveillanceReport.setReportDate(new Date());
+            }
+        }
 
         // Update diagnosis date if provided
         final LocalDate diagnosticDate = notifierForm.getDiagnosticDate();
-        if(diagnosticDate != null) {
+        if (diagnosticDate != null) {
             surveillanceReport.setDateOfDiagnosis(Date.from(diagnosticDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
         } else {
             surveillanceReport.setDateOfDiagnosis(null);

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/notifier/CaseNotifierSideViewController.java
@@ -344,12 +344,16 @@ public class CaseNotifierSideViewController {
      */
     private void updateSurveillanceReportFromForm(SurveillanceReportDto surveillanceReport, CaseNotifierForm notifierForm) {
         // Update report date from notification date
-        final LocalDate notificationDate = notifierForm.getNotificationDate();
+        final LocalDate notificationDate = notifierForm.getNotificationDate() == null ? LocalDate.now() : notifierForm.getNotificationDate();
         surveillanceReport.setReportDate(Date.from(notificationDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
 
         // Update diagnosis date if provided
         final LocalDate diagnosticDate = notifierForm.getDiagnosticDate();
-        surveillanceReport.setDateOfDiagnosis(Date.from(diagnosticDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+        if(diagnosticDate != null) {
+            surveillanceReport.setDateOfDiagnosis(Date.from(diagnosticDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+        } else {
+            surveillanceReport.setDateOfDiagnosis(null);
+        }
 
         // Update treatment based on selected option
         final TreatmentOption selectedOption = notifierForm.getSelectedTreatmentOption();


### PR DESCRIPTION
Fixes a NPE when the date of diagnosis is not filled in the create notification dialog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date handling for case notifications and diagnoses: when a notification date is missing the report date will default to the current date only if not previously set; diagnostic dates are now cleared when not provided. This prevents incorrect or stale dates from being recorded and reduces processing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->