### PR TITLE
Fixes: Display manual case classification.

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/disease/DiseaseConfigurationFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/disease/DiseaseConfigurationFacadeEjb.java
@@ -444,7 +444,7 @@ public class DiseaseConfigurationFacadeEjb implements DiseaseConfigurationFacade
 	}
 
 	public String getCaseDefinitionText(Disease disease) {
-		return service.getDiseaseConfiguration(disease).getCaseDefinitionText();
+		return service.getDiseaseConfiguration(disease) == null ? null : service.getDiseaseConfiguration(disease).getCaseDefinitionText();
 	}
 
 	@Override

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseDataForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseDataForm.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import de.symeda.sormas.api.person.PersonReferenceDto;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -54,6 +53,7 @@ import com.vaadin.ui.Button;
 import com.vaadin.ui.GridLayout;
 import com.vaadin.ui.Image;
 import com.vaadin.ui.Label;
+import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.Window;
 import com.vaadin.ui.Window.CloseListener;
 import com.vaadin.ui.themes.ValoTheme;
@@ -70,6 +70,7 @@ import com.vaadin.v7.ui.OptionGroup;
 import com.vaadin.v7.ui.TextArea;
 import com.vaadin.v7.ui.TextField;
 
+import de.symeda.sormas.api.CaseClassificationCalculationMode;
 import de.symeda.sormas.api.CountryHelper;
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.DiseaseHelper;
@@ -115,6 +116,7 @@ import de.symeda.sormas.api.infrastructure.facility.FacilityType;
 import de.symeda.sormas.api.infrastructure.facility.FacilityTypeGroup;
 import de.symeda.sormas.api.infrastructure.region.RegionReferenceDto;
 import de.symeda.sormas.api.person.PersonDto;
+import de.symeda.sormas.api.person.PersonReferenceDto;
 import de.symeda.sormas.api.person.Sex;
 import de.symeda.sormas.api.sample.PathogenTestDto;
 import de.symeda.sormas.api.sample.SampleDto;
@@ -1361,15 +1363,26 @@ public class CaseDataForm extends AbstractEditForm<CaseDataDto> {
 
 		// Automatic case classification rules button - invisible for other diseases
 		DiseaseClassificationCriteriaDto diseaseClassificationCriteria = FacadeProvider.getCaseClassificationFacade().getByDisease(disease);
-		if (diseaseClassificationExists()) {
-			Button classificationRulesButton = ButtonHelper.createIconButton(
-				Captions.info,
-				VaadinIcons.INFO_CIRCLE,
-				e -> ControllerProvider.getCaseController().openClassificationRulesPopup(diseaseClassificationCriteria),
-				ValoTheme.BUTTON_PRIMARY,
-				FORCE_CAPTION);
 
-			getContent().addComponent(classificationRulesButton, CLASSIFICATION_RULES_LOC);
+		CaseClassificationCalculationMode caseClassificationCalculationMode =
+			FacadeProvider.getConfigFacade().getCaseClassificationCalculationMode(disease);
+		// If case classification is not disabled for the disease.
+		if (CaseClassificationCalculationMode.DISABLED != caseClassificationCalculationMode) {
+			// If automatic classification is enabled for the disease and it has the classification criteria.
+			if (FacadeProvider.getConfigFacade().getCaseClassificationCalculationMode(disease).isAutomaticEnabled()
+				&& diseaseClassificationExists()) {
+				Button classificationRulesButton = ButtonHelper.createIconButton(
+					Captions.info,
+					VaadinIcons.INFO_CIRCLE,
+					e -> ControllerProvider.getCaseController().openClassificationRulesPopup(diseaseClassificationCriteria),
+					ValoTheme.BUTTON_PRIMARY,
+					FORCE_CAPTION);
+
+				getContent().addComponent(classificationRulesButton, CLASSIFICATION_RULES_LOC);
+			} else {
+				// If Manual classification is enabled for the disease.
+				getManualCaseDefinition();
+			}
 		}
 
 		addField(CaseDataDto.DELETION_REASON);
@@ -1523,6 +1536,37 @@ public class CaseDataForm extends AbstractEditForm<CaseDataDto> {
 			CaseDataDto.CLINICIAN_PHONE,
 			CaseDataDto.CLINICIAN_EMAIL,
 			CaseDataDto.ADDITIONAL_DETAILS);
+	}
+
+	/**
+	 * If a manual case definition is configured in the properties files and has the case definition in the disease configuration,
+	 * then display the button with case definition.
+	 */
+	private void getManualCaseDefinition() {
+		// If a disease has caseDefinitionText, it should display; otherwise criteria will display as it is.
+		String caseDefinitionText = FacadeProvider.getDiseaseConfigurationFacade().getCaseDefinitionText(disease);
+		if (caseDefinitionText == null) {
+			return;
+		}
+
+		Button caseDefinitionButton = ButtonHelper.createIconButton(Captions.info, VaadinIcons.INFO_CIRCLE, e -> {
+			VerticalLayout classificationRulesLayout = new VerticalLayout();
+			classificationRulesLayout.setMargin(true);
+			Label suspectContent = new Label();
+			suspectContent.setContentMode(ContentMode.HTML);
+			suspectContent.setWidth(100, Unit.PERCENTAGE);
+			suspectContent.setValue(caseDefinitionText);
+			classificationRulesLayout.addComponent(suspectContent);
+			Window popupWindow = VaadinUiUtil.showPopupWindow(classificationRulesLayout);
+			popupWindow.addCloseListener(e1 -> {
+				popupWindow.close();
+			});
+			popupWindow.setWidth(860, Unit.PIXELS);
+			popupWindow.setHeight(80, Unit.PERCENTAGE);
+			popupWindow.setCaption(I18nProperties.getString(Strings.classificationRulesFor) + " " + disease);
+		}, ValoTheme.BUTTON_PRIMARY, FORCE_CAPTION);
+
+		getContent().addComponent(caseDefinitionButton, CLASSIFICATION_RULES_LOC);
 	}
 
 	private void hideJurisdictionFields() {


### PR DESCRIPTION
Summary:
Displaying the manual classification, which has configured in disease level Changes:
Verifying the caseClassificationMode, if it's DISABLED, does nothing. For AUTOMATIC, display the automatic case classification in the table. For MANUAL, display the plain text box with the configured details.

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes # Display manual case classification.
Summary:
Displaying the manual classification, which has configured in disease level
Changes:
Verifying the caseClassificationMode, if it's DISABLED, does nothing.
For AUTOMATIC, display the automatic case classification in the table.
For MANUAL, display the plain text box with the configured details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a case definition popup that displays disease-specific case definition text in the classification UI.

* **Improvements**
  * Classification workflow now adapts to configuration: shows rules when automatic classification applies, otherwise presents manual case-definition flow.

* **Bug Fixes**
  * Prevented errors when disease configuration is missing by safely handling absent configuration before accessing case definition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->