### PR TITLE
Defaulting the exposure setting to "Mosquito-borne" for malaria and d…

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/exposure/ExposureForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/exposure/ExposureForm.java
@@ -31,6 +31,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import com.vaadin.icons.VaadinIcons;
 import com.vaadin.shared.ui.ContentMode;
@@ -500,7 +501,12 @@ public class ExposureForm extends AbstractEditForm<ExposureDto> {
 		FieldHelper.updateItems(settingField, settings);
 
 		// Clear the field and its dependent details field
-		settingField.setValue(null);
+		// if the disease is Malaria or Dengue and the category is VECTOR_BORNE, preselect MOSQUITO_BORNE as setting (since it's the only valid option in this case)
+		ExposureSetting defaultSetting =
+			Stream.of(Disease.MALARIA, Disease.DENGUE).anyMatch(d -> d == disease) && category == ExposureCategory.VECTOR_BORNE
+				? ExposureSetting.MOSQUITO_BORNE
+				: null;
+		settingField.setValue(defaultSetting);
 		settingDetailsField.setValue(null);
 		settingDetailsField.setVisible(false);
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/exposure/ExposuresField.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/exposure/ExposuresField.java
@@ -74,6 +74,7 @@ public class ExposuresField extends AbstractTableField<ExposureDto> {
 	private static final String COLUMN_DATE = Captions.date;
 	private static final String COLUMN_ADDRESS = Captions.address;
 	private static final String COLUMN_DESCRIPTION = ExposureDto.DESCRIPTION;
+	private static final String COLUMN_PROPHYLAXIS_ADHERENCE = ExposureDto.PROPHYLAXIS_ADHERENCE;
 
 	private final FieldVisibilityCheckers fieldVisibilityCheckers;
 	private Supplier<List<ContactReferenceDto>> getSourceContactsCallback;
@@ -106,6 +107,7 @@ public class ExposuresField extends AbstractTableField<ExposureDto> {
 				ACTION_COLUMN_ID,
 				COLUMN_EXPOSURE_CATEGORY,
 				COLUMN_EXPOSURE_SETTING,
+				COLUMN_PROPHYLAXIS_ADHERENCE,
 				COLUMN_DATE,
 				COLUMN_ADDRESS,
 				COLUMN_DESCRIPTION);
@@ -165,7 +167,6 @@ public class ExposuresField extends AbstractTableField<ExposureDto> {
 				if (exposure.getSubSettings() != null && !exposure.getSubSettings().isEmpty()) {
 					return exposure.getSubSettings().stream().map(Object::toString).collect(Collectors.joining(", "));
 				}
-				return "";
 
 			default:
 				return exposure.getExposureSetting() != null ? exposure.getExposureSetting().toString() : "";
@@ -190,6 +191,10 @@ public class ExposuresField extends AbstractTableField<ExposureDto> {
 			}
 
 			return descriptionLabel;
+		});
+		table.addGeneratedColumn(COLUMN_PROPHYLAXIS_ADHERENCE, (Table.ColumnGenerator) (source, itemId, columnId) -> {
+			ExposureDto exposure = (ExposureDto) itemId;
+			return exposure.getProphylaxisAdherence() != null ? exposure.getProphylaxisAdherence().toString() : "";
 		});
 	}
 


### PR DESCRIPTION
…engue diseases.

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Exposure entry forms now automatically pre-select appropriate default vector-borne settings when documenting Malaria and Dengue cases, streamlining data entry and improving consistency
  * Case exposure data tables now display a dedicated prophylaxis adherence column for comprehensive tracking and monitoring of preventive medication compliance across case records

<!-- end of auto-generated comment: release notes by coderabbit.ai -->