### PR TITLE
🐛: FIX: #13830: National user cannot assign case or event

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserService.java
@@ -241,7 +241,7 @@ public class UserService extends AdoServiceWithUserFilterAndJurisdiction<User> {
 				CriteriaBuilderHelper.or(
 					cb,
 					cb.in(regionJoin.get(AbstractDomainObject.UUID)).value(regionUuids),
-					createCurrentUserHasNationJurisdictionFilter(cb, userRoot)));
+					createUserHasNationJurisdictionFilter(cb, userRoot)));
 			userEntityJoinUsed = true;
 		}
 		if (CollectionUtils.isNotEmpty(districtUuids)) {
@@ -258,7 +258,7 @@ public class UserService extends AdoServiceWithUserFilterAndJurisdiction<User> {
 					cb.equal(root.get(UserReference.JURISDICTION_LEVEL), JurisdictionLevel.REGION)));
 
 			filter = CriteriaBuilderHelper
-				.and(cb, filter, CriteriaBuilderHelper.or(cb, districtFilter, createCurrentUserHasNationJurisdictionFilter(cb, userRoot)));
+				.and(cb, filter, CriteriaBuilderHelper.or(cb, districtFilter, createUserHasNationJurisdictionFilter(cb, userRoot)));
 			userEntityJoinUsed = true;
 		}
 		if (!hasRight(UserRight.SEE_PERSONAL_DATA_OUTSIDE_JURISDICTION)) {
@@ -267,8 +267,7 @@ public class UserService extends AdoServiceWithUserFilterAndJurisdiction<User> {
 			filter = CriteriaBuilderHelper.and(
 				cb,
 				filter,
-				CriteriaBuilderHelper
-					.or(cb, createCurrentUserJurisdictionFilter(cb, userRoot), createCurrentUserHasNationJurisdictionFilter(cb, userRoot)));
+				CriteriaBuilderHelper.or(cb, createCurrentUserJurisdictionFilter(cb, userRoot), createUserHasNationJurisdictionFilter(cb, userRoot)));
 			userEntityJoinUsed = true;
 		}
 
@@ -306,7 +305,7 @@ public class UserService extends AdoServiceWithUserFilterAndJurisdiction<User> {
 				CriteriaBuilderHelper.or(
 					cb,
 					cb.in(communityJoin.get(AbstractDomainObject.UUID)).value(communityUuids),
-					createCurrentUserHasNationJurisdictionFilter(cb, userRoot)));
+					createUserHasNationJurisdictionFilter(cb, userRoot)));
 		}
 
 		if (filter != null) {
@@ -728,14 +727,7 @@ public class UserService extends AdoServiceWithUserFilterAndJurisdiction<User> {
 		}
 	}
 
-	public Predicate createCurrentUserHasNationJurisdictionFilter(CriteriaBuilder cb, From<?, User> from) {
-		User currentUser = getCurrentUser();
-
-		if (currentUser.getJurisdictionLevel() == JurisdictionLevel.NATION) {
-			logger.error("getJurisdictionLevel = NATION");
-			return cb.equal(from.get(User.JURISDICTION_LEVEL), JurisdictionLevel.NATION);
-		}
-
+	public Predicate createUserHasNationJurisdictionFilter(CriteriaBuilder cb, From<?, User> from) {
 		return cb.equal(from.get(User.JURISDICTION_LEVEL), JurisdictionLevel.NATION);
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserService.java
@@ -15,14 +15,7 @@
 package de.symeda.sormas.backend.user;
 
 import java.text.MessageFormat;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import javax.ejb.EJB;
@@ -30,16 +23,7 @@ import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.persistence.TypedQuery;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Expression;
-import javax.persistence.criteria.From;
-import javax.persistence.criteria.Join;
-import javax.persistence.criteria.JoinType;
-import javax.persistence.criteria.ParameterExpression;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
-import javax.persistence.criteria.Subquery;
+import javax.persistence.criteria.*;
 import javax.transaction.Transactional;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -48,13 +32,7 @@ import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.infrastructure.InfrastructureHelper;
 import de.symeda.sormas.api.infrastructure.facility.FacilityType;
 import de.symeda.sormas.api.infrastructure.region.RegionReferenceDto;
-import de.symeda.sormas.api.user.JurisdictionLevel;
-import de.symeda.sormas.api.user.NotificationProtocol;
-import de.symeda.sormas.api.user.NotificationType;
-import de.symeda.sormas.api.user.UserCriteria;
-import de.symeda.sormas.api.user.UserRight;
-import de.symeda.sormas.api.user.UserRoleDto;
-import de.symeda.sormas.api.user.UserRoleReferenceDto;
+import de.symeda.sormas.api.user.*;
 import de.symeda.sormas.api.utils.DataHelper;
 import de.symeda.sormas.api.utils.DefaultEntityHelper;
 import de.symeda.sormas.api.utils.PasswordHelper;
@@ -254,11 +232,21 @@ public class UserService extends AdoServiceWithUserFilterAndJurisdiction<User> {
 		boolean userEntityJoinUsed = false;
 
 		if (CollectionUtils.isNotEmpty(regionUuids)) {
+			logger.debug("regionUuids: [{}]", regionUuids);
 			Join<User, Region> regionJoin = userRoot.join(User.REGION, JoinType.LEFT);
-			filter = CriteriaBuilderHelper.and(cb, filter, cb.in(regionJoin.get(AbstractDomainObject.UUID)).value(regionUuids));
+
+			filter = CriteriaBuilderHelper.and(
+				cb,
+				filter,
+				CriteriaBuilderHelper.or(
+					cb,
+					cb.in(regionJoin.get(AbstractDomainObject.UUID)).value(regionUuids),
+					createCurrentUserHasNationJurisdictionFilter(cb, userRoot)));
 			userEntityJoinUsed = true;
 		}
 		if (CollectionUtils.isNotEmpty(districtUuids)) {
+			logger.debug("districtUuids: [{}]", districtUuids);
+
 			Join<User, District> districtJoin = userRoot.join(User.DISTRICT, JoinType.LEFT);
 			Join<User, Region> userRegionJoin = userRoot.join(User.REGION, JoinType.LEFT);
 			Join<Region, District> districtRegionJoin = userRegionJoin.join(Region.DISTRICTS, JoinType.LEFT);
@@ -269,11 +257,18 @@ public class UserService extends AdoServiceWithUserFilterAndJurisdiction<User> {
 					cb.in(districtRegionJoin.get(AbstractDomainObject.UUID)).value(districtUuids),
 					cb.equal(root.get(UserReference.JURISDICTION_LEVEL), JurisdictionLevel.REGION)));
 
-			filter = CriteriaBuilderHelper.and(cb, filter, districtFilter);
+			filter = CriteriaBuilderHelper
+				.and(cb, filter, CriteriaBuilderHelper.or(cb, districtFilter, createCurrentUserHasNationJurisdictionFilter(cb, userRoot)));
 			userEntityJoinUsed = true;
 		}
 		if (!hasRight(UserRight.SEE_PERSONAL_DATA_OUTSIDE_JURISDICTION)) {
-			filter = CriteriaBuilderHelper.and(cb, filter, createCurrentUserJurisdictionFilter(cb, userRoot));
+			logger.debug("Not looking for user right [SEE_PERSONAL_DATA_OUTSIDE_JURISDICTION]");
+
+			filter = CriteriaBuilderHelper.and(
+				cb,
+				filter,
+				CriteriaBuilderHelper
+					.or(cb, createCurrentUserJurisdictionFilter(cb, userRoot), createCurrentUserHasNationJurisdictionFilter(cb, userRoot)));
 			userEntityJoinUsed = true;
 		}
 
@@ -298,12 +293,20 @@ public class UserService extends AdoServiceWithUserFilterAndJurisdiction<User> {
 
 		//exlude users with limited diseases
 		if (excludeLimitedDiseaseUsers) {
+			logger.debug("Search will be limited to diseases of the user");
 			filter = CriteriaBuilderHelper.and(cb, filter, cb.isNull(userRoot.get(User.LIMITED_DISEASES)));
 		}
 
 		if (CollectionUtils.isNotEmpty(communityUuids)) {
+			logger.debug("communityUuids: [{}]", communityUuids);
 			Join<User, Community> communityJoin = userRoot.join(User.COMMUNITY, JoinType.LEFT);
-			filter = CriteriaBuilderHelper.and(cb, filter, cb.in(communityJoin.get(AbstractDomainObject.UUID)).value(communityUuids));
+			filter = CriteriaBuilderHelper.and(
+				cb,
+				filter,
+				CriteriaBuilderHelper.or(
+					cb,
+					cb.in(communityJoin.get(AbstractDomainObject.UUID)).value(communityUuids),
+					createCurrentUserHasNationJurisdictionFilter(cb, userRoot)));
 		}
 
 		if (filter != null) {
@@ -725,9 +728,21 @@ public class UserService extends AdoServiceWithUserFilterAndJurisdiction<User> {
 		}
 	}
 
+	public Predicate createCurrentUserHasNationJurisdictionFilter(CriteriaBuilder cb, From<?, User> from) {
+		User currentUser = getCurrentUser();
+
+		if (currentUser.getJurisdictionLevel() == JurisdictionLevel.NATION) {
+			logger.error("getJurisdictionLevel = NATION");
+			return cb.equal(from.get(User.JURISDICTION_LEVEL), JurisdictionLevel.NATION);
+		}
+
+		return cb.equal(from.get(User.JURISDICTION_LEVEL), JurisdictionLevel.NATION);
+	}
+
 	public Predicate buildUserRightsFilter(Root<User> from, Collection<UserRight> userRights) {
 
 		if (userRights != null && !userRights.isEmpty()) {
+			logger.error("User rights: [{}]", userRights);
 			Join<User, UserRole> rolesJoin = from.join(User.USER_ROLES, JoinType.LEFT);
 			Join<UserRole, UserRight> rightsJoin = rolesJoin.join(UserRole.USER_RIGHTS, JoinType.LEFT);
 			return rightsJoin.in(Collections.singletonList(userRights));

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserService.java
@@ -734,7 +734,7 @@ public class UserService extends AdoServiceWithUserFilterAndJurisdiction<User> {
 	public Predicate buildUserRightsFilter(Root<User> from, Collection<UserRight> userRights) {
 
 		if (userRights != null && !userRights.isEmpty()) {
-			logger.error("User rights: [{}]", userRights);
+			logger.debug("Requested user rights: [{}]", userRights);
 			Join<User, UserRole> rolesJoin = from.join(User.USER_ROLES, JoinType.LEFT);
 			Join<UserRole, UserRight> rightsJoin = rolesJoin.join(UserRole.USER_RIGHTS, JoinType.LEFT);
 			return rightsJoin.in(Collections.singletonList(userRights));

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/user/UserFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/user/UserFacadeEjbTest.java
@@ -1,46 +1,21 @@
 package de.symeda.sormas.backend.user;
 
-import static de.symeda.sormas.api.user.DefaultUserRole.ADMIN_SUPERVISOR;
-import static de.symeda.sormas.api.user.DefaultUserRole.CASE_OFFICER;
-import static de.symeda.sormas.api.user.DefaultUserRole.CONTACT_OFFICER;
-import static de.symeda.sormas.api.user.DefaultUserRole.CONTACT_SUPERVISOR;
-import static de.symeda.sormas.api.user.DefaultUserRole.DISTRICT_OBSERVER;
-import static de.symeda.sormas.api.user.DefaultUserRole.NATIONAL_USER;
-import static de.symeda.sormas.api.user.DefaultUserRole.POE_INFORMANT;
-import static de.symeda.sormas.api.user.DefaultUserRole.REST_EXTERNAL_VISITS_USER;
-import static de.symeda.sormas.api.user.DefaultUserRole.SURVEILLANCE_OFFICER;
-import static de.symeda.sormas.api.user.DefaultUserRole.SURVEILLANCE_SUPERVISOR;
+import static de.symeda.sormas.api.user.DefaultUserRole.*;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import javax.persistence.EntityNotFoundException;
 import javax.validation.ValidationException;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -50,12 +25,9 @@ import org.mockito.MockitoAnnotations;
 import de.symeda.sormas.api.AuthProvider;
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.EntityDto;
+import de.symeda.sormas.api.ReferenceDto;
 import de.symeda.sormas.api.infrastructure.region.RegionReferenceDto;
-import de.symeda.sormas.api.user.UserCriteria;
-import de.symeda.sormas.api.user.UserDto;
-import de.symeda.sormas.api.user.UserFacade;
-import de.symeda.sormas.api.user.UserReferenceDto;
-import de.symeda.sormas.api.user.UserRight;
+import de.symeda.sormas.api.user.*;
 import de.symeda.sormas.api.utils.AccessDeniedException;
 import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.backend.AbstractBeanTest;
@@ -310,6 +282,27 @@ public class UserFacadeEjbTest extends AbstractBeanTest {
 	}
 
 	@Test
+	public void testGetUserRefsByRegionForResponsibleSurveillanceOfficer() {
+		RDCF rdcf = creator.createRDCF();
+		RDCF rdcfOther = creator.createRDCF("otherRegion", "oderDistrict", "otherCommunity", "otherFacility");
+
+		UserDto surveilanceOfficerDefault = creator.createSurveillanceOfficer(rdcf);
+		UserDto surveilanceSupervisorDefault = creator.createSurveillanceSupervisor(rdcf);
+		UserDto adminSupervisorDefault = creator.createUser(rdcf, "Admin", "Supervisor", creator.getUserRoleReference(ADMIN_SUPERVISOR));
+		UserDto adminSupervisorOther = creator.createUser(rdcfOther, "Admin", "Supervisor Other", creator.getUserRoleReference(ADMIN_SUPERVISOR));
+
+		List<UserReferenceDto> userReferenceDtos =
+			getUserFacade().getUsersByRegionAndRights(rdcf.region, Disease.CORONAVIRUS, UserRight.CASE_RESPONSIBLE);
+		assertNotNull(userReferenceDtos);
+		assertEquals(3, userReferenceDtos.size());
+		List<String> userReferenceUUIDs = userReferenceDtos.stream().map(u -> u.getUuid()).collect(Collectors.toList());
+		assertTrue(userReferenceUUIDs.contains(surveilanceOfficerDefault.getUuid()));
+		assertTrue(userReferenceUUIDs.contains(surveilanceSupervisorDefault.getUuid()));
+		assertTrue(userReferenceUUIDs.contains(adminSupervisorDefault.getUuid()));
+		assertFalse(userReferenceUUIDs.contains(adminSupervisorOther.getUuid()));
+	}
+
+	@Test
 	public void testGetUserRefsByDistrictsForResponsibleSurveillanceOfficer() {
 		RDCF rdcf = creator.createRDCF();
 		RDCF rdcfOther = creator.createRDCF("otherRegion", "oderDistrict", "otherCommunity", "otherFacility");
@@ -327,6 +320,42 @@ public class UserFacadeEjbTest extends AbstractBeanTest {
 		assertTrue(userReferenceUUIDs.contains(surveilanceSupervisorDefault.getUuid()));
 		assertTrue(userReferenceUUIDs.contains(adminSupervisorDefault.getUuid()));
 		assertFalse(userReferenceUUIDs.contains(adminSupervisorOther.getUuid()));
+	}
+
+	@Test
+	public void testGetUserRefsByDistrictsForResponsibleSurveillanceOfficer_national_user() {
+		RDCF rdcf = creator.createRDCF();
+
+		UserDto surveilanceOfficerDefault = creator.createSurveillanceOfficer(rdcf);
+		UserDto surveilanceSupervisorDefault = creator.createSurveillanceSupervisor(rdcf);
+		UserDto nationalUser = creator.createUser(rdcf, "national", "user", creator.getUserRoleReference(NATIONAL_USER));
+
+		List<UserReferenceDto> userReferenceDtos = getUserFacade().getUserRefsByDistricts(Arrays.asList(rdcf.district), Disease.CORONAVIRUS);
+		List<String> userReferenceUUIDs = userReferenceDtos.stream().map(ReferenceDto::getUuid).collect(Collectors.toList());
+
+		Assertions.assertAll(
+			() -> assertEquals(4, userReferenceDtos.size()),
+			() -> assertTrue(userReferenceUUIDs.contains(surveilanceOfficerDefault.getUuid())),
+			() -> assertTrue(userReferenceUUIDs.contains(surveilanceSupervisorDefault.getUuid())),
+			() -> assertTrue(userReferenceUUIDs.contains(nationalUser.getUuid())));
+	}
+
+	@Test
+	public void testGetUserRefsByRegionForResponsibleSurveillanceOfficer_national_user() {
+		RDCF rdcf = creator.createRDCF();
+
+		UserDto surveilanceOfficerDefault = creator.createSurveillanceOfficer(rdcf);
+		UserDto surveilanceSupervisorDefault = creator.createSurveillanceSupervisor(rdcf);
+		UserDto nationalUser = creator.createUser(rdcf, "national", "user", creator.getUserRoleReference(NATIONAL_USER));
+
+		List<UserReferenceDto> userReferenceDtos = getUserFacade().getUsersByRegionAndRights(rdcf.region, Disease.CORONAVIRUS);
+		List<String> userReferenceUUIDs = userReferenceDtos.stream().map(ReferenceDto::getUuid).collect(Collectors.toList());
+
+		Assertions.assertAll(
+			() -> assertEquals(4, userReferenceDtos.size()),
+			() -> assertTrue(userReferenceUUIDs.contains(surveilanceOfficerDefault.getUuid())),
+			() -> assertTrue(userReferenceUUIDs.contains(surveilanceSupervisorDefault.getUuid())),
+			() -> assertTrue(userReferenceUUIDs.contains(nationalUser.getUuid())));
 	}
 
 	@Test


### PR DESCRIPTION
 National user cannot assign case even though it's enabled in user role configuration. 

#13830

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #13830

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user reference filtering to correctly include users with national jurisdiction level alongside region, district, and community-based selections.
  * Enhanced jurisdiction-based access restrictions to properly account for national jurisdiction users when visibility permissions are limited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->