### PR TITLE
Disabled the sorting for "type of contact" column, while it's a list of values, instead of a single.

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/AbstractContactGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/AbstractContactGrid.java
@@ -171,13 +171,16 @@ public abstract class AbstractContactGrid<IndexDto extends ContactIndexDto> exte
 			getColumn(CaseIndexDto.EXTERNAL_ID).setHidden(true);
 			getColumn(CaseIndexDto.EXTERNAL_TOKEN).setHidden(true);
 		}
-		getColumn(ContactIndexDto.CONTACT_PROXIMITIES).setWidth(200);
-		((Column<ContactIndexDto, Set<ContactProximity>>) getColumn(ContactIndexDto.CONTACT_PROXIMITIES)).setRenderer(proximities -> {
+		Column<ContactIndexDto, Set<ContactProximity>> contactProximityColumn =
+			(Column<ContactIndexDto, Set<ContactProximity>>) getColumn(ContactIndexDto.CONTACT_PROXIMITIES);
+		contactProximityColumn.setWidth(200);
+		contactProximityColumn.setRenderer(proximities -> {
 			if (proximities == null || proximities.isEmpty()) {
 				return "";
 			}
 			return proximities.stream().map(I18nProperties::getEnumCaption).collect(Collectors.joining(", "));
 		}, new com.vaadin.ui.renderers.TextRenderer());
+		contactProximityColumn.setSortable(false);
 		((Column<ContactIndexDto, String>) getColumn(ContactIndexDto.UUID)).setRenderer(new UuidRenderer());
 		((Column<ContactIndexDto, String>) getColumn(ContactIndexDto.PERSON_UUID)).setRenderer(new UuidRenderer());
 		((Column<ContactIndexDto, Date>) getColumn(ContactIndexDto.FOLLOW_UP_UNTIL)).setRenderer(new DateRenderer(DateFormatHelper.getDateFormat()));


### PR DESCRIPTION
…es, not a single value.

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the way contact proximity data is configured in the contact list.
  * Kept the displayed values unchanged: empty entries still show blank, and multiple proximity values are shown as a comma-separated list.
  * Maintains the same column width and non-sortable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->