### PR TITLE
#14032 - Refactor immunization exclusion logic for CaseDataView and ContactDataView

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseDataView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseDataView.java
@@ -14,7 +14,9 @@
  */
 package de.symeda.sormas.ui.caze;
 
-import java.util.List;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -98,6 +100,14 @@ public class CaseDataView extends AbstractCaseView implements HasName {
 	public static final String CASE_NOTIFIER_LOC = "caseNotifier";
 	private static final long serialVersionUID = -1L;
 	private CommitDiscardWrapperComponent<CaseDataForm> editComponent;
+
+	//@formatter:off
+	private static final Set<Disease> IMMUNIZATION_EXCLUDED_DISEASES = new HashSet<>(Arrays.asList(
+		Disease.GIARDIASIS, 
+		Disease.CRYPTOSPORIDIOSIS, 
+		Disease.SALMONELLOSIS, 
+		Disease.SHIGELLOSIS));
+	//@formatter:on
 
 	public CaseDataView() {
 		super(VIEW_NAME, false);
@@ -184,30 +194,28 @@ public class CaseDataView extends AbstractCaseView implements HasName {
 			layout.addSidePanelComponent(eventLayout, EVENTS_LOC);
 		}
 
-		if (UiUtil.permitted(FeatureType.IMMUNIZATION_MANAGEMENT, UserRight.IMMUNIZATION_VIEW)) {
-			// Immunizations are not shown for Giardiasis, Cryptosporidiosis, and Salmonellosis
-			if (!List.of(Disease.GIARDIASIS, Disease.CRYPTOSPORIDIOSIS, Disease.SALMONELLOSIS).contains(caze.getDisease())) {
-				final VaccinationStatusPanel vaccinationStatusPanel = ControllerProvider.getCaseController().createVaccinationStatusPanel(caze);
-				if (caze.getVaccinationStatusLastUpdated() == null && UiUtil.permitted(UserRight.IMMUNIZATION_EDIT)) {
-					showVaccinationStatusUpdateDialog(caze);
-				}
-				if (!FacadeProvider.getFeatureConfigurationFacade()
-					.isPropertyValueTrue(FeatureType.IMMUNIZATION_MANAGEMENT, FeatureTypeProperty.REDUCED)) {
-					layout.addSidePanelComponent(new SideComponentLayout(new ImmunizationListComponent(() -> {
-						CaseDataDto refreshedCase = FacadeProvider.getCaseFacade().getCaseDataByUuid(getCaseRef().getUuid());
-						return new ImmunizationListCriteria.Builder(refreshedCase.getPerson()).withDisease(refreshedCase.getDisease()).build();
-					}, null, this::showUnsavedChangesPopup, isEditAllowed, vaccinationStatusPanel, SormasUI::refreshView)), IMMUNIZATION_LOC);
-				} else {
-					layout.addSidePanelComponent(new SideComponentLayout(new VaccinationListComponent(() -> {
-						CaseDataDto refreshedCase = FacadeProvider.getCaseFacade().getCaseDataByUuid(getCaseRef().getUuid());
-						return new VaccinationCriteria.Builder(refreshedCase.getPerson()).withDisease(refreshedCase.getDisease())
-							.build()
-							.vaccinationAssociationType(VaccinationAssociationType.CASE)
-							.caseReference(getCaseRef())
-							.region(refreshedCase.getResponsibleRegion())
-							.district(refreshedCase.getResponsibleDistrict());
-					}, null, this::showUnsavedChangesPopup, isEditAllowed)), VACCINATIONS_LOC);
-				}
+		if (!IMMUNIZATION_EXCLUDED_DISEASES.contains(caze.getDisease())
+			&& UiUtil.permitted(FeatureType.IMMUNIZATION_MANAGEMENT, UserRight.IMMUNIZATION_VIEW)) {
+			final VaccinationStatusPanel vaccinationStatusPanel = ControllerProvider.getCaseController().createVaccinationStatusPanel(caze);
+			if (caze.getVaccinationStatusLastUpdated() == null && UiUtil.permitted(UserRight.IMMUNIZATION_EDIT)) {
+				showVaccinationStatusUpdateDialog(caze);
+			}
+			if (!FacadeProvider.getFeatureConfigurationFacade()
+				.isPropertyValueTrue(FeatureType.IMMUNIZATION_MANAGEMENT, FeatureTypeProperty.REDUCED)) {
+				layout.addSidePanelComponent(new SideComponentLayout(new ImmunizationListComponent(() -> {
+					CaseDataDto refreshedCase = FacadeProvider.getCaseFacade().getCaseDataByUuid(getCaseRef().getUuid());
+					return new ImmunizationListCriteria.Builder(refreshedCase.getPerson()).withDisease(refreshedCase.getDisease()).build();
+				}, null, this::showUnsavedChangesPopup, isEditAllowed, vaccinationStatusPanel, SormasUI::refreshView)), IMMUNIZATION_LOC);
+			} else {
+				layout.addSidePanelComponent(new SideComponentLayout(new VaccinationListComponent(() -> {
+					CaseDataDto refreshedCase = FacadeProvider.getCaseFacade().getCaseDataByUuid(getCaseRef().getUuid());
+					return new VaccinationCriteria.Builder(refreshedCase.getPerson()).withDisease(refreshedCase.getDisease())
+						.build()
+						.vaccinationAssociationType(VaccinationAssociationType.CASE)
+						.caseReference(getCaseRef())
+						.region(refreshedCase.getResponsibleRegion())
+						.district(refreshedCase.getResponsibleDistrict());
+				}, null, this::showUnsavedChangesPopup, isEditAllowed)), VACCINATIONS_LOC);
 			}
 		}
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/ContactDataView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/ContactDataView.java
@@ -15,7 +15,9 @@
 package de.symeda.sormas.ui.contact;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.vaadin.server.Page;
 import com.vaadin.shared.ui.ContentMode;
@@ -99,7 +101,13 @@ public class ContactDataView extends AbstractContactView implements HasName {
 
 	private CommitDiscardWrapperComponent<ContactDataForm> editComponent;
 
-	private final static List<Disease> IMMUNIZATION_EXCLUDED_DISEASES = Arrays.asList(Disease.SALMONELLOSIS, Disease.SHIGELLOSIS);
+	//@formatter:off
+	private static final Set<Disease> IMMUNIZATION_EXCLUDED_DISEASES = new HashSet<>(Arrays.asList(
+		Disease.GIARDIASIS, 
+		Disease.CRYPTOSPORIDIOSIS, 
+		Disease.SALMONELLOSIS, 
+		Disease.SHIGELLOSIS));
+	//@formatter:on
 
 	public ContactDataView() {
 		super(VIEW_NAME);


### PR DESCRIPTION
Fixes #14032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved immunization section visibility so it is no longer shown for additional excluded diseases in contact records.
  * Kept immunization-related panels hidden for cases with excluded diseases, while preserving the existing display options for other records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->