### PR TITLE
#14058 - Add 'performedByReferenceLaboratory' field to TestReport and related classes

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/labmessage/TestReportDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/labmessage/TestReportDto.java
@@ -71,6 +71,7 @@ public class TestReportDto extends EntityDto {
 	public static final String PRESCRIBER_POSTAL_CODE = "prescriberPostalCode";
 	public static final String PRESCRIBER_CITY = "prescriberCity";
 	public static final String PRESCRIBER_COUNTRY = "prescriberCountry";
+	public static final String PERFORMED_BY_REFERENCE_LABORATORY = "performedByReferenceLaboratory";
 
 	@NotNull(message = Validations.requiredField)
 	private SampleReportReferenceDto sampleReport;
@@ -220,6 +221,7 @@ public class TestReportDto extends EntityDto {
 
 	private PathogenTestCategory pathogenTestCategory;
 	private boolean fourFoldIncreaseAntibodyTiter;
+	private Boolean performedByReferenceLaboratory;
 
 	public SampleReportReferenceDto getSampleReport() {
 		return sampleReport;
@@ -930,6 +932,14 @@ public class TestReportDto extends EntityDto {
 
 	public void setFourFoldIncreaseAntibodyTiter(boolean fourFoldIncreaseAntibodyTiter) {
 		this.fourFoldIncreaseAntibodyTiter = fourFoldIncreaseAntibodyTiter;
+	}
+
+	public Boolean getPerformedByReferenceLaboratory() {
+		return performedByReferenceLaboratory;
+	}
+
+	public void setPerformedByReferenceLaboratory(Boolean performedByReferenceLaboratory) {
+		this.performedByReferenceLaboratory = performedByReferenceLaboratory;
 	}
 
 }

--- a/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/processing/ExternalMessageMapper.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/processing/ExternalMessageMapper.java
@@ -55,7 +55,6 @@ import de.symeda.sormas.api.person.PhoneNumberType;
 import de.symeda.sormas.api.sample.PathogenTestDto;
 import de.symeda.sormas.api.sample.PathogenTestResultType;
 import de.symeda.sormas.api.sample.SampleDto;
-import de.symeda.sormas.api.sample.Serotype;
 import de.symeda.sormas.api.therapy.DrugSusceptibilityDto;
 import de.symeda.sormas.api.utils.DataHelper;
 import de.symeda.sormas.api.utils.DateHelper;
@@ -994,7 +993,12 @@ public final class ExternalMessageMapper {
 							pathogenTest::setFourFoldIncreaseAntibodyTiter,
 							pathogenTest.isFourFoldIncreaseAntibodyTiter(),
 							sourceTestReport.getFourFoldIncreaseAntibodyTiter(),
-							PathogenTestDto.FOUR_FOLD_INCREASE_ANTIBODY_TITER))
+							PathogenTestDto.FOUR_FOLD_INCREASE_ANTIBODY_TITER),
+						Mapping.of(
+							pathogenTest::setPerformedByReferenceLaboratory,
+							pathogenTest.getPerformedByReferenceLaboratory(),
+							sourceTestReport.getPerformedByReferenceLaboratory(),
+							PathogenTestDto.PERFORMED_BY_REFERENCE_LABORATORY))
 
 				));
 		}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/externalmessage/labmessage/TestReport.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/externalmessage/labmessage/TestReport.java
@@ -184,6 +184,7 @@ public class TestReport extends AbstractDomainObject {
 	private String serotypeText;
 	private PathogenTestCategory pathogenTestCategory;
 	private boolean fourFoldIncreaseAntibodyTiter;
+	private Boolean performedByReferenceLaboratory;
 
 	@Column(length = CHARACTER_LIMIT_DEFAULT)
 	public String getTestLabName() {
@@ -953,6 +954,15 @@ public class TestReport extends AbstractDomainObject {
 
 	public void setFourFoldIncreaseAntibodyTiter(boolean fourFoldIncreaseAntibodyTiter) {
 		this.fourFoldIncreaseAntibodyTiter = fourFoldIncreaseAntibodyTiter;
+	}
+
+	@Column
+	public Boolean getPerformedByReferenceLaboratory() {
+		return performedByReferenceLaboratory;
+	}
+
+	public void setPerformedByReferenceLaboratory(Boolean performedByReferenceLaboratory) {
+		this.performedByReferenceLaboratory = performedByReferenceLaboratory;
 	}
 
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/externalmessage/labmessage/TestReportFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/externalmessage/labmessage/TestReportFacadeEjb.java
@@ -166,6 +166,7 @@ public class TestReportFacadeEjb implements TestReportFacade {
 		target.setSerotypeText(source.getSerotypeText());
 		target.setPathogenTestCategory(source.getPathogenTestCategory());
 		target.setFourFoldIncreaseAntibodyTiter(source.getFourFoldIncreaseAntibodyTiter());
+		target.setPerformedByReferenceLaboratory(source.getPerformedByReferenceLaboratory());
 
 		return target;
 	}
@@ -219,6 +220,7 @@ public class TestReportFacadeEjb implements TestReportFacade {
 		target.setTubeMitogene(source.getTubeMitogene());
 		target.setTubeMitogeneGT10(source.getTubeMitogeneGT10());
 		target.setStrainCallStatus(source.getStrainCallStatus());
+		target.setPerformedByReferenceLaboratory(source.getPerformedByReferenceLaboratory());
 
 		// Drug susceptibility mappings
 		target.setAmikacinMic(source.getAmikacinMic());
@@ -268,6 +270,7 @@ public class TestReportFacadeEjb implements TestReportFacade {
 		target.setSerotypeText(source.getSerotypeText());
 		target.setPathogenTestCategory(source.getPathogenTestCategory());
 		target.setFourFoldIncreaseAntibodyTiter(source.getFourFoldIncreaseAntibodyTiter());
+		target.setPerformedByReferenceLaboratory(source.getPerformedByReferenceLaboratory());
 
 		return target;
 	}

--- a/sormas-backend/src/main/resources/sql/sormas_schema.sql
+++ b/sormas-backend/src/main/resources/sql/sormas_schema.sql
@@ -16401,4 +16401,12 @@ ALTER TABLE testreport_history ADD COLUMN IF NOT EXISTS fourfoldincreaseantibody
 
 INSERT INTO schema_version (version_number, comment) VALUES (641, 'Malaria and Dengue DD and Lab message processing fixes');
 
+
+-- 2025-06-36 Performed by reference laboratory missing for lab messages
+
+ALTER TABLE testreport ADD COLUMN IF NOT EXISTS performedbyreferencelaboratory boolean;
+ALTER TABLE testreport_history ADD COLUMN IF NOT EXISTS performedbyreferencelaboratory boolean;
+
+INSERT INTO schema_version (version_number, comment) VALUES (642, '#14058 - Performed by reference laboratory not toggled');
+
 -- *** Insert new sql commands BEFORE this line. Remember to always consider _history tables. ***

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/externalmessage/labmessage/TestReportFacadeEjbMappingTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/externalmessage/labmessage/TestReportFacadeEjbMappingTest.java
@@ -125,6 +125,7 @@ public class TestReportFacadeEjbMappingTest {
 		source.setSeroGroupSpecificationText("SeroGroup A");
 		source.setSeroTypingMethod(SerotypingMethod.MULTIPLEX_PCR);
 		source.setSeroTypingMethodText("Multiplex PCR Method");
+		source.setPerformedByReferenceLaboratory(true);
 
 		TestReport result = sut.fromDto(source, true);
 
@@ -194,6 +195,7 @@ public class TestReportFacadeEjbMappingTest {
 		assertEquals(source.getSeroGroupSpecificationText(), result.getSeroGroupSpecificationText());
 		assertEquals(source.getSeroTypingMethod(), result.getSeroTypingMethod());
 		assertEquals(source.getSeroTypingMethodText(), result.getSeroTypingMethodText());
+		assertEquals(source.getPerformedByReferenceLaboratory(), result.getPerformedByReferenceLaboratory());
 
 	}
 
@@ -275,6 +277,7 @@ public class TestReportFacadeEjbMappingTest {
 		source.setSeroTypingMethodText("Multiplex PCR Method");
 		source.setSerotype(Serotype.OTHER);
 		source.setSerotypeText("Other Serotype");
+		source.setPerformedByReferenceLaboratory(true);
 
 		TestReportDto result = TestReportFacadeEjb.toDto(source);
 
@@ -347,5 +350,6 @@ public class TestReportFacadeEjbMappingTest {
 		assertEquals(source.getSeroTypingMethodText(), result.getSeroTypingMethodText());
 		assertEquals(source.getSerotype(), result.getSerotype());
 		assertEquals(source.getSerotypeText(), result.getSerotypeText());
+		assertEquals(source.getPerformedByReferenceLaboratory(), result.getPerformedByReferenceLaboratory());
 	}
 }


### PR DESCRIPTION
Fixes #14058

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “performed by reference laboratory” flag to lab test reports and exposed it in the user-facing lab message data.

* **Bug Fixes**
  * Ensured the flag is preserved correctly when converting between lab message formats and when saving/loading test report records (including history).
  * Updated the database schema to store the new value for both current and historical entries.

* **Tests**
  * Extended mapping tests to verify the flag is handled correctly in both directions (DTO ↔ persisted/report objects).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->