### PR TITLE
#14016 - drop malaria specific resultdetails

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/i18n/Captions.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/i18n/Captions.java
@@ -2427,7 +2427,6 @@ public interface Captions {
 	String PathogenTest_quantitativeUnit = "PathogenTest.quantitativeUnit";
 	String PathogenTest_quantitativeValue = "PathogenTest.quantitativeValue";
 	String PathogenTest_reportDate = "PathogenTest.reportDate";
-	String PathogenTest_resultDetails = "PathogenTest.resultDetails";
 	String PathogenTest_retestRequested = "PathogenTest.retestRequested";
 	String PathogenTest_rifampicinResistant = "PathogenTest.rifampicinResistant";
 	String PathogenTest_rsv_testedDiseaseVariant = "PathogenTest.rsv.testedDiseaseVariant";

--- a/sormas-api/src/main/java/de/symeda/sormas/api/sample/PathogenTestDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/sample/PathogenTestDto.java
@@ -128,7 +128,6 @@ public class PathogenTestDto extends PseudonymizableDto {
 	public static final String ANTIBODY_TITRE = "antibodyTitre";
 	public static final String PERFORMED_BY_REFERENCE_LABORATORY = "performedByReferenceLaboratory";
 	public static final String RETEST_REQUESTED = "retestRequested";
-	public static final String RESULT_DETAILS = "resultDetails";
 	public static final String QUANTITATIVE_VALUE = "quantitativeValue";
 	public static final String QUANTITATIVE_UNIT = "quantitativeUnit";
 	public static final String QUANTITATIVE_BOOLEAN = "quantitativeBoolean";
@@ -336,10 +335,6 @@ public class PathogenTestDto extends PseudonymizableDto {
 	private Boolean performedByReferenceLaboratory;
 	// defaulting this test to false.
 	private Boolean retestRequested = false;
-	@Diseases({
-		Disease.MALARIA })
-	@Size(max = FieldConstraints.CHARACTER_LIMIT_DEFAULT, message = Validations.textTooLong)
-	private String resultDetails;
 
 	// Generic quantitative result fields, shown per the test method's ResultValueType (issue #13952).
 	private Float quantitativeValue;
@@ -968,14 +963,6 @@ public class PathogenTestDto extends PseudonymizableDto {
 
 	public void setRetestRequested(Boolean retestRequested) {
 		this.retestRequested = retestRequested;
-	}
-
-	public String getResultDetails() {
-		return resultDetails;
-	}
-
-	public void setResultDetails(String resultDetails) {
-		this.resultDetails = resultDetails;
 	}
 
 	public String getSerotypeText() {

--- a/sormas-api/src/main/resources/captions.properties
+++ b/sormas-api/src/main/resources/captions.properties
@@ -2009,7 +2009,6 @@ PathogenTest.tubeMitogeneGT10=Tube Mitogen >10
 PathogenTest.antibodyTitre=Antibody titre
 PathogenTest.performedByReferenceLaboratory=Performed by reference laboratory
 PathogenTest.retestRequested=Retest requested
-PathogenTest.resultDetails=Result details
 PathogenTest.quantitativeValue=Value
 PathogenTest.quantitativeUnit=Unit
 PathogenTest.quantitativeBoolean=Detected

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/PathogenTest.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/PathogenTest.java
@@ -189,7 +189,6 @@ public class PathogenTest extends DeletableAdo {
 	private String antibodyTitre;
 	private Boolean performedByReferenceLaboratory;
 	private Boolean retestRequested;
-	private String resultDetails;
 	private Float quantitativeValue;
 	private String quantitativeUnit;
 	private YesNoUnknown quantitativeBoolean;
@@ -812,14 +811,6 @@ public class PathogenTest extends DeletableAdo {
 
 	public void setRetestRequested(Boolean retestRequested) {
 		this.retestRequested = retestRequested;
-	}
-
-	public String getResultDetails() {
-		return resultDetails;
-	}
-
-	public void setResultDetails(String resultDetails) {
-		this.resultDetails = resultDetails;
 	}
 
 	public String getSpecieText() {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/PathogenTestFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/PathogenTestFacadeEjb.java
@@ -348,7 +348,6 @@ public class PathogenTestFacadeEjb implements PathogenTestFacade {
 		target.setAntibodyTitre(source.getAntibodyTitre());
 		target.setPerformedByReferenceLaboratory(source.getPerformedByReferenceLaboratory());
 		target.setRetestRequested(source.getRetestRequested());
-		target.setResultDetails(source.getResultDetails());
 		target.setQuantitativeValue(source.getQuantitativeValue());
 		target.setQuantitativeUnit(source.getQuantitativeUnit());
 		target.setQuantitativeBoolean(source.getQuantitativeBoolean());
@@ -678,7 +677,6 @@ public class PathogenTestFacadeEjb implements PathogenTestFacade {
 		target.setAntibodyTitre(source.getAntibodyTitre());
 		target.setPerformedByReferenceLaboratory(source.getPerformedByReferenceLaboratory());
 		target.setRetestRequested(source.getRetestRequested());
-		target.setResultDetails(source.getResultDetails());
 		target.setQuantitativeValue(source.getQuantitativeValue());
 		target.setQuantitativeUnit(source.getQuantitativeUnit());
 		target.setQuantitativeBoolean(source.getQuantitativeBoolean());

--- a/sormas-backend/src/main/resources/sql/sormas_schema.sql
+++ b/sormas-backend/src/main/resources/sql/sormas_schema.sql
@@ -16419,13 +16419,18 @@ BEGIN
     IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'pathogentest' AND column_name = 'resultdetails') THEN
         SELECT count(*) INTO truncated_count FROM pathogentest
             WHERE resultdetails IS NOT NULL AND resultdetails <> ''
-              AND length(CASE WHEN testresulttext IS NULL OR testresulttext = '' THEN resultdetails ELSE testresulttext || E'\n' || resultdetails END) > 4096;
+              AND length(CASE
+                  WHEN testresulttext IS NULL OR testresulttext = '' THEN resultdetails
+                  WHEN testresulttext = resultdetails THEN testresulttext
+                  ELSE testresulttext || E'\n' || resultdetails
+              END) > 4096;
         IF truncated_count > 0 THEN
             RAISE NOTICE 'Migration 642: % pathogentest row(s) had their preserved resultdetails truncated to fit varchar(4096).', truncated_count;
         END IF;
         UPDATE pathogentest
         SET testresulttext = LEFT(CASE
             WHEN testresulttext IS NULL OR testresulttext = '' THEN resultdetails
+            WHEN testresulttext = resultdetails THEN testresulttext
             ELSE testresulttext || E'\n' || resultdetails
         END, 4096)
         WHERE resultdetails IS NOT NULL AND resultdetails <> '';
@@ -16433,13 +16438,18 @@ BEGIN
     IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'pathogentest_history' AND column_name = 'resultdetails') THEN
         SELECT count(*) INTO truncated_count FROM pathogentest_history
             WHERE resultdetails IS NOT NULL AND resultdetails <> ''
-              AND length(CASE WHEN testresulttext IS NULL OR testresulttext = '' THEN resultdetails ELSE testresulttext || E'\n' || resultdetails END) > 4096;
+              AND length(CASE
+                  WHEN testresulttext IS NULL OR testresulttext = '' THEN resultdetails
+                  WHEN testresulttext = resultdetails THEN testresulttext
+                  ELSE testresulttext || E'\n' || resultdetails
+              END) > 4096;
         IF truncated_count > 0 THEN
             RAISE NOTICE 'Migration 642: % pathogentest_history row(s) had their preserved resultdetails truncated to fit varchar(4096).', truncated_count;
         END IF;
         UPDATE pathogentest_history
         SET testresulttext = LEFT(CASE
             WHEN testresulttext IS NULL OR testresulttext = '' THEN resultdetails
+            WHEN testresulttext = resultdetails THEN testresulttext
             ELSE testresulttext || E'\n' || resultdetails
         END, 4096)
         WHERE resultdetails IS NOT NULL AND resultdetails <> '';

--- a/sormas-backend/src/main/resources/sql/sormas_schema.sql
+++ b/sormas-backend/src/main/resources/sql/sormas_schema.sql
@@ -16360,7 +16360,7 @@ BEGIN
             WHERE quantitativetext IS NOT NULL AND quantitativetext <> ''
               AND length(CASE WHEN testresulttext IS NULL OR testresulttext = '' THEN quantitativetext ELSE testresulttext || E'\n' || quantitativetext END) > 4096;
         IF truncated_count > 0 THEN
-            RAISE NOTICE 'Migration 640: % pathogentest row(s) had their preserved quantitativetext truncated to fit varchar(4096).', truncated_count;
+            RAISE NOTICE 'Migration 639: % pathogentest row(s) had their preserved quantitativetext truncated to fit varchar(4096).', truncated_count;
         END IF;
         UPDATE pathogentest
         SET testresulttext = LEFT(CASE
@@ -16374,7 +16374,7 @@ BEGIN
             WHERE quantitativetext IS NOT NULL AND quantitativetext <> ''
               AND length(CASE WHEN testresulttext IS NULL OR testresulttext = '' THEN quantitativetext ELSE testresulttext || E'\n' || quantitativetext END) > 4096;
         IF truncated_count > 0 THEN
-            RAISE NOTICE 'Migration 640: % pathogentest_history row(s) had their preserved quantitativetext truncated to fit varchar(4096).', truncated_count;
+            RAISE NOTICE 'Migration 639: % pathogentest_history row(s) had their preserved quantitativetext truncated to fit varchar(4096).', truncated_count;
         END IF;
         UPDATE pathogentest_history
         SET testresulttext = LEFT(CASE
@@ -16400,5 +16400,54 @@ ALTER TABLE testreport ADD COLUMN IF NOT EXISTS fourfoldincreaseantibodytiter bo
 ALTER TABLE testreport_history ADD COLUMN IF NOT EXISTS fourfoldincreaseantibodytiter boolean DEFAULT false;
 
 INSERT INTO schema_version (version_number, comment) VALUES (641, 'Malaria and Dengue DD and Lab message processing fixes');
+
+-- 2026-06-29 Remove Malaria-specific "Result details" pathogen test field (issue #14016)
+-- The Malaria resultdetails field duplicated the generic "Test result details" (testresulttext) field on the
+-- pathogen test form. Drop it and fold any captured value into testresulttext so no free-text result is lost.
+-- Both pathogentest and pathogentest_history are migrated.
+--
+-- versioning_trigger on pathogentest mirrors every UPDATE into pathogentest_history & disable it for the
+-- migration window so the backfill does not inject phantom audit rows, and re-enable when done.
+--
+-- testresulttext is varchar(4096) while resultdetails is varchar(255): LEFT(..., 4096) guards against a
+-- near-full testresulttext overflowing the column once resultdetails is appended.
+ALTER TABLE pathogentest DISABLE TRIGGER versioning_trigger;
+DO $$
+DECLARE
+    truncated_count integer;
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'pathogentest' AND column_name = 'resultdetails') THEN
+        SELECT count(*) INTO truncated_count FROM pathogentest
+            WHERE resultdetails IS NOT NULL AND resultdetails <> ''
+              AND length(CASE WHEN testresulttext IS NULL OR testresulttext = '' THEN resultdetails ELSE testresulttext || E'\n' || resultdetails END) > 4096;
+        IF truncated_count > 0 THEN
+            RAISE NOTICE 'Migration 642: % pathogentest row(s) had their preserved resultdetails truncated to fit varchar(4096).', truncated_count;
+        END IF;
+        UPDATE pathogentest
+        SET testresulttext = LEFT(CASE
+            WHEN testresulttext IS NULL OR testresulttext = '' THEN resultdetails
+            ELSE testresulttext || E'\n' || resultdetails
+        END, 4096)
+        WHERE resultdetails IS NOT NULL AND resultdetails <> '';
+    END IF;
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'pathogentest_history' AND column_name = 'resultdetails') THEN
+        SELECT count(*) INTO truncated_count FROM pathogentest_history
+            WHERE resultdetails IS NOT NULL AND resultdetails <> ''
+              AND length(CASE WHEN testresulttext IS NULL OR testresulttext = '' THEN resultdetails ELSE testresulttext || E'\n' || resultdetails END) > 4096;
+        IF truncated_count > 0 THEN
+            RAISE NOTICE 'Migration 642: % pathogentest_history row(s) had their preserved resultdetails truncated to fit varchar(4096).', truncated_count;
+        END IF;
+        UPDATE pathogentest_history
+        SET testresulttext = LEFT(CASE
+            WHEN testresulttext IS NULL OR testresulttext = '' THEN resultdetails
+            ELSE testresulttext || E'\n' || resultdetails
+        END, 4096)
+        WHERE resultdetails IS NOT NULL AND resultdetails <> '';
+    END IF;
+END $$;
+ALTER TABLE pathogentest DROP COLUMN IF EXISTS resultdetails;
+ALTER TABLE pathogentest_history DROP COLUMN IF EXISTS resultdetails;
+ALTER TABLE pathogentest ENABLE TRIGGER versioning_trigger;
+INSERT INTO schema_version (version_number, comment) VALUES (642, 'Remove Malaria-specific result details pathogen test column, preserving values into testresulttext issue #14016');
 
 -- *** Insert new sql commands BEFORE this line. Remember to always consider _history tables. ***

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/diseasesection/MalariaSectionComponent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/diseasesection/MalariaSectionComponent.java
@@ -66,13 +66,9 @@ public class MalariaSectionComponent extends AbstractDiseaseSectionComponent {
 		PathogenTestType.OTHER_SEROLOGICAL_TEST,
 		PathogenTestType.OTHER_MOLECULAR_ASSAY);
 
-	private static final List<PathogenTestType> RESULT_DETAILS_VISIBLE_TYPES =
-		Arrays.asList(PathogenTestType.THIN_BLOOD_SMEAR, PathogenTestType.Q_PCR);
-
 	private ComboBox<PathogenSpecie> specieField;
 	private TextField specieTextField;
 	private Label specieTextSpacer;
-	private TextField resultDetailsField;
 
 	private PathogenTestType currentTestType;
 	private PathogenTestResultType currentResult;
@@ -90,13 +86,8 @@ public class MalariaSectionComponent extends AbstractDiseaseSectionComponent {
 		specieTextSpacer = createSpacer();
 		addToggleRow(specieField, specieTextField, specieTextSpacer);
 
-		resultDetailsField = createTextField(PathogenTestDto.RESULT_DETAILS);
-		resultDetailsField.setVisible(false);
-		addRow(resultDetailsField, createSpacer());
-
 		binder.forField(specieField).bind(PathogenTestDto::getSpecie, PathogenTestDto::setSpecie);
 		binder.forField(specieTextField).bind(PathogenTestDto::getSpecieText, PathogenTestDto::setSpecieText);
-		binder.forField(resultDetailsField).bind(PathogenTestDto::getResultDetails, PathogenTestDto::setResultDetails);
 	}
 
 	@Override
@@ -138,12 +129,6 @@ public class MalariaSectionComponent extends AbstractDiseaseSectionComponent {
 			specieTextField.clear();
 		}
 
-		boolean showResultDetails = RESULT_DETAILS_VISIBLE_TYPES.contains(currentTestType);
-		resultDetailsField.setVisible(showResultDetails);
-		if (!showResultDetails) {
-			resultDetailsField.clear();
-		}
-
 		updateRowAndSelfVisibility();
 	}
 
@@ -155,6 +140,5 @@ public class MalariaSectionComponent extends AbstractDiseaseSectionComponent {
 		}
 		dto.setSpecie(null);
 		dto.setSpecieText(null);
-		dto.setResultDetails(null);
 	}
 }


### PR DESCRIPTION
…e existing testresulttext

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #14016 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified pathogen test data entry by removing the separate “result details” field.
  * Existing result details are now consolidated into the main test result information to preserve what users entered.
  * Updated malaria-related UI behavior to hide the removed field and ensure consistent clearing and data handling.
  * Improved related test fields, including antibody titre validation, reference-lab tracking, and a default “retest requested” value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->