### PR TITLE
Allowing configurable value override when equal and DataReplacementStrategy.IF_NOT_ALREADY_PRESENT

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/patch/DataPatcherImpl.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/patch/DataPatcherImpl.java
@@ -1,6 +1,12 @@
 package de.symeda.sormas.backend.patch;
 
-import java.util.*;
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -22,7 +28,15 @@ import de.symeda.sormas.api.caze.CaseDataDto;
 import de.symeda.sormas.api.customizablefield.CustomizableFieldValueDto;
 import de.symeda.sormas.api.externalmessage.survey.PatchDictionary;
 import de.symeda.sormas.api.externalmessage.survey.PatchField;
-import de.symeda.sormas.api.patch.*;
+import de.symeda.sormas.api.patch.CaseDataPatchRequest;
+import de.symeda.sormas.api.patch.DataPatchFailure;
+import de.symeda.sormas.api.patch.DataPatchFailureCause;
+import de.symeda.sormas.api.patch.DataPatchResponse;
+import de.symeda.sormas.api.patch.DataPatcher;
+import de.symeda.sormas.api.patch.DataReplacementStrategy;
+import de.symeda.sormas.api.patch.EmptyValueBehavior;
+import de.symeda.sormas.api.patch.PlainSinglePatchResult;
+import de.symeda.sormas.api.patch.SinglePatchResult;
 import de.symeda.sormas.api.patch.mapping.FieldCustomMapper;
 import de.symeda.sormas.api.patch.mapping.FieldPatchRequest;
 import de.symeda.sormas.api.patch.mapping.ValueMappingResult;
@@ -32,7 +46,11 @@ import de.symeda.sormas.api.utils.fieldvisibility.FieldVisibilityCheckers;
 import de.symeda.sormas.backend.common.ConfigFacadeEjb;
 import de.symeda.sormas.backend.feature.FeatureConfigurationFacadeEjb;
 import de.symeda.sormas.backend.json.ObjectMapperProvider;
-import de.symeda.sormas.backend.patch.customizablefield.*;
+import de.symeda.sormas.backend.patch.customizablefield.CustomizableContextIndexKey;
+import de.symeda.sormas.backend.patch.customizablefield.CustomizableFieldContextPatchMapping;
+import de.symeda.sormas.backend.patch.customizablefield.CustomizableFieldDataPatchRequest;
+import de.symeda.sormas.backend.patch.customizablefield.CustomizableFieldDataPatcher;
+import de.symeda.sormas.backend.patch.customizablefield.CustomizableFieldSinglePatchingResult;
 import de.symeda.sormas.backend.patch.mapping.FieldCustomMapperRegistry;
 import de.symeda.sormas.backend.patch.mapping.PatchEqualityCheckersRegistry;
 import de.symeda.sormas.backend.patch.mapping.ValueMapperRegistry;
@@ -66,6 +84,9 @@ public class DataPatcherImpl implements DataPatcher {
 
 	@Inject
 	private CustomizableFieldDataPatcher customizableFieldDataPatcher;
+
+	@Inject
+	private EqualValueOverrideHelper equalValueOverrideHelper;
 
 	public DataPatcherImpl() {
 	}
@@ -273,7 +294,7 @@ public class DataPatcherImpl implements DataPatcher {
 			return singlePatchResult.setFailure(buildFailure(dataPatchFailureCause, untypedTargetValue));
 		}
 
-		Object typedValue = result.getData();
+		Object newTypedValue = result.getData();
 
 		if (!attachedEntityWrapper.isAttached() && !StringUtils.contains(relativeFieldName, ".")) {
 			logger.debug(
@@ -286,19 +307,25 @@ public class DataPatcherImpl implements DataPatcher {
 			if (nestedPropertyValue.isPresent()) {
 				Object currentValue = nestedPropertyValue.orElseThrow();
 
-				if (!patchEqualityCheckersRegistry.areEqual(currentValue, typedValue)) {
-					return singlePatchResult.setFailure(
-						new DataPatchFailure().setDataPatchFailureCause(DataPatchFailureCause.FORBIDDEN_VALUE_OVERRIDE)
-							.setExistingFieldValue(currentValue)
-							.setProvidedFieldValue(untypedTargetValue));
+				if (!patchEqualityCheckersRegistry.areEqual(currentValue, newTypedValue)) {
+					if (equalValueOverrideHelper.allowedOverride(currentValue)) {
+						logger.info(
+							"Current value to [{}] was different to newValue but override was allowed for this value even if config was: DataReplacementStrategy.IF_NOT_ALREADY_PRESENT",
+							currentValue);
+					} else {
+						return singlePatchResult.setFailure(
+							new DataPatchFailure().setDataPatchFailureCause(DataPatchFailureCause.FORBIDDEN_VALUE_OVERRIDE)
+								.setExistingFieldValue(currentValue)
+								.setProvidedFieldValue(untypedTargetValue));
+					}
 				}
 			}
 		}
 
-		Optional<Exception> exception = PropertyAccessor.setNestedProperty(target, relativeFieldName, typedValue);
+		Optional<Exception> exception = PropertyAccessor.setNestedProperty(target, relativeFieldName, newTypedValue);
 		if (exception.isPresent()) {
 			Exception e = exception.orElseThrow();
-			logger.error("Setting nested property failed for: field [{}] on [{}] with value: [{}]", relativeFieldName, target, typedValue, e);
+			logger.error("Setting nested property failed for: field [{}] on [{}] with value: [{}]", relativeFieldName, target, newTypedValue, e);
 			return singlePatchResult.setFailure(
 				new DataPatchFailure().setDataPatchFailureCause(DataPatchFailureCause.TECHNICAL).setProvidedFieldValue(untypedTargetValue));
 		} else {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/patch/EqualValueOverrideHelper.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/patch/EqualValueOverrideHelper.java
@@ -1,0 +1,62 @@
+package de.symeda.sormas.backend.patch;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.ejb.EJB;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.jetbrains.annotations.NotNull;
+
+import de.symeda.sormas.api.systemconfiguration.SystemConfigurationValueFacade;
+import de.symeda.sormas.backend.util.StringNormalizer;
+
+/**
+ * Due to values being sometime set by external sources (Lab messages) in a non-optimal manner,
+ * some fields have "fallback"-values that should be allowed to be overridden.
+ */
+@ApplicationScoped
+public class EqualValueOverrideHelper {
+
+	public static final String ALLOWED_EQUALITY_VALUE_OVERRIDE_KEY = "ALLOWED_EQUALITY_VALUE_OVERRIDE";
+
+	@EJB
+	private SystemConfigurationValueFacade systemConfigurationValueFacade;
+
+	/**
+	 * If current value and new value to patch are different, (depending on config, see below) it must be checked if override is still
+	 * allowed.
+	 * {@link de.symeda.sormas.api.patch.DataReplacementStrategy#IF_NOT_ALREADY_PRESENT}
+	 * 
+	 * @param value
+	 *            **current** value that is different from the new value in the system.
+	 * @return true: means the value even can be overridden, false: cannot be overridden because not part of exceptions.
+	 */
+	public boolean allowedOverride(Object value) {
+		String valueAsString = StringNormalizer.normalize(value.toString());
+
+		Set<String> allowedEqualityOverrides = resolveConfiguredForbiddenFields();
+
+		return allowedEqualityOverrides.contains(valueAsString)
+			|| allowedEqualityOverrides.contains(getValueAsStringWithTypePrefix(value, valueAsString));
+	}
+
+	private static @NotNull String getValueAsStringWithTypePrefix(Object value, String valueAsString) {
+		return StringNormalizer.normalize(String.format("%s___%s", value.getClass().getSimpleName(), valueAsString));
+	}
+
+	private Set<String> resolveConfiguredForbiddenFields() {
+		String configValue = systemConfigurationValueFacade.getValue(ALLOWED_EQUALITY_VALUE_OVERRIDE_KEY);
+		return Optional.ofNullable(configValue)
+			.filter(candidate -> !candidate.isBlank())
+			.map(
+				candidate -> Arrays.stream(candidate.split(","))
+					.map(StringNormalizer::normalize)
+					.filter(s -> !s.isEmpty())
+					.collect(Collectors.toSet()))
+			.orElse(Collections.EMPTY_SET);
+	}
+}

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/patch/EqualValueOverrideHelperTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/patch/EqualValueOverrideHelperTest.java
@@ -1,0 +1,138 @@
+package de.symeda.sormas.backend.patch;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import de.symeda.sormas.api.symptoms.SymptomState;
+import de.symeda.sormas.api.systemconfiguration.SystemConfigurationValueFacade;
+import de.symeda.sormas.api.utils.YesNoUnknown;
+import de.symeda.sormas.backend.AbstractUnitTest;
+
+class EqualValueOverrideHelperTest extends AbstractUnitTest {
+
+	@InjectMocks
+	private EqualValueOverrideHelper victim;
+
+	@Mock
+	private SystemConfigurationValueFacade systemConfigurationValueFacade;
+
+	@Test
+	void allowedOverride_configuredValueMatchesPlainValue_returnsTrue() {
+		// PREPARE
+		when(systemConfigurationValueFacade.getValue(EqualValueOverrideHelper.ALLOWED_EQUALITY_VALUE_OVERRIDE_KEY)).thenReturn("UNKNOWN, OTHER");
+
+		// EXECUTE
+		boolean result = victim.allowedOverride("UNKNOWN");
+
+		// CHECK
+		assertTrue(result);
+	}
+
+	@Test
+	void allowedOverride_configuredValueMatchesTypePrefixedValue_returnsTrue() {
+		// PREPARE
+		when(systemConfigurationValueFacade.getValue(EqualValueOverrideHelper.ALLOWED_EQUALITY_VALUE_OVERRIDE_KEY)).thenReturn("Integer___42");
+
+		// EXECUTE
+		boolean result = victim.allowedOverride(42);
+
+		// CHECK
+		assertTrue(result);
+	}
+
+	@Test
+	void allowedOverride_configuredValueMatchesTypePrefixedValue_unknown_returnsTrue() {
+		// PREPARE
+		when(systemConfigurationValueFacade.getValue(EqualValueOverrideHelper.ALLOWED_EQUALITY_VALUE_OVERRIDE_KEY))
+			.thenReturn("YesNoUnknown___UNKNOWN");
+
+		// EXECUTE & CHECK
+		assertTrue(victim.allowedOverride(YesNoUnknown.UNKNOWN));
+		assertFalse(victim.allowedOverride(SymptomState.UNKNOWN));
+	}
+
+	@Test
+	void allowedOverride_configuredValueDoesNotMatch_returnsFalse() {
+		// PREPARE
+		when(systemConfigurationValueFacade.getValue(EqualValueOverrideHelper.ALLOWED_EQUALITY_VALUE_OVERRIDE_KEY)).thenReturn("SOME_OTHER_VALUE");
+
+		// EXECUTE
+		boolean result = victim.allowedOverride("UNKNOWN");
+
+		// CHECK
+		assertFalse(result);
+	}
+
+	@Test
+	void allowedOverride_configValueNull_valueNotInDefaults_returnsFalse() {
+		// PREPARE
+		when(systemConfigurationValueFacade.getValue(EqualValueOverrideHelper.ALLOWED_EQUALITY_VALUE_OVERRIDE_KEY)).thenReturn(null);
+
+		// EXECUTE
+		boolean result = victim.allowedOverride("NotAForbiddenField");
+
+		// CHECK
+		assertFalse(result);
+	}
+
+	@Test
+	void allowedOverride_configValueWithWhitespaceAroundEntries_trimsEntries() {
+		// PREPARE
+		when(systemConfigurationValueFacade.getValue(EqualValueOverrideHelper.ALLOWED_EQUALITY_VALUE_OVERRIDE_KEY)).thenReturn(" foo , bar ,, ");
+
+		// EXECUTE & CHECK
+		assertTrue(victim.allowedOverride("foo"));
+		assertTrue(victim.allowedOverride("bar"));
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+		"FOO, foo",
+		"foo, FOO",
+		"Foo, fOO",
+		"café, cafe",
+		"CAFÉ, cafe",
+		"'  foo  ', foo",
+		"'Café   Au   Lait', cafe au lait" })
+	void allowedOverride_configuredAndInputValuesDifferByCaseAccentsOrWhitespace_stillMatch(String configuredValue, String inputValue) {
+		// PREPARE
+		when(systemConfigurationValueFacade.getValue(EqualValueOverrideHelper.ALLOWED_EQUALITY_VALUE_OVERRIDE_KEY)).thenReturn(configuredValue);
+
+		// EXECUTE
+		boolean result = victim.allowedOverride(inputValue);
+
+		// CHECK
+		assertTrue(result);
+	}
+
+	@Test
+	void allowedOverride_typePrefixedConfiguredValueDifferentCase_stillMatches() {
+		// PREPARE
+		when(systemConfigurationValueFacade.getValue(EqualValueOverrideHelper.ALLOWED_EQUALITY_VALUE_OVERRIDE_KEY)).thenReturn("INTEGER___42");
+
+		// EXECUTE
+		boolean result = victim.allowedOverride(42);
+
+		// CHECK
+		assertTrue(result);
+	}
+
+	@Test
+	void allowedOverride_normalizedValuesDifferBeyondCaseAccentsOrWhitespace_returnsFalse() {
+		// PREPARE
+		when(systemConfigurationValueFacade.getValue(EqualValueOverrideHelper.ALLOWED_EQUALITY_VALUE_OVERRIDE_KEY)).thenReturn("FOO");
+
+		// EXECUTE
+		boolean result = victim.allowedOverride("foobar");
+
+		// CHECK
+		assertFalse(result);
+	}
+}

--- a/sormas-backend/src/test/java/de/symeda/sormas/patch/DataPatcherImplTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/patch/DataPatcherImplTest.java
@@ -27,7 +27,12 @@ import de.symeda.sormas.api.caze.CaseDataDto;
 import de.symeda.sormas.api.caze.Vaccine;
 import de.symeda.sormas.api.customizableenum.CustomizableEnumTranslation;
 import de.symeda.sormas.api.customizableenum.CustomizableEnumType;
-import de.symeda.sormas.api.customizablefield.*;
+import de.symeda.sormas.api.customizablefield.CustomizableFieldContext;
+import de.symeda.sormas.api.customizablefield.CustomizableFieldGroup;
+import de.symeda.sormas.api.customizablefield.CustomizableFieldMetadataDto;
+import de.symeda.sormas.api.customizablefield.CustomizableFieldMetadataFacade;
+import de.symeda.sormas.api.customizablefield.CustomizableFieldType;
+import de.symeda.sormas.api.customizablefield.CustomizableFieldValueDto;
 import de.symeda.sormas.api.exposure.ExposureDto;
 import de.symeda.sormas.api.exposure.ExposureType;
 import de.symeda.sormas.api.externalmessage.survey.PatchDictionary;
@@ -40,9 +45,23 @@ import de.symeda.sormas.api.immunization.ImmunizationStatus;
 import de.symeda.sormas.api.infrastructure.country.CountryDto;
 import de.symeda.sormas.api.infrastructure.country.CountryReferenceDto;
 import de.symeda.sormas.api.infrastructure.facility.FacilityDto;
-import de.symeda.sormas.api.patch.*;
-import de.symeda.sormas.api.person.*;
+import de.symeda.sormas.api.patch.CaseDataPatchRequest;
+import de.symeda.sormas.api.patch.DataPatchFailure;
+import de.symeda.sormas.api.patch.DataPatchFailureCause;
+import de.symeda.sormas.api.patch.DataPatchResponse;
+import de.symeda.sormas.api.patch.DataPatcher;
+import de.symeda.sormas.api.patch.DataReplacementStrategy;
+import de.symeda.sormas.api.patch.EmptyValueBehavior;
+import de.symeda.sormas.api.person.OccupationType;
+import de.symeda.sormas.api.person.PersonContactDetailDto;
+import de.symeda.sormas.api.person.PersonContactDetailType;
+import de.symeda.sormas.api.person.PersonDto;
+import de.symeda.sormas.api.person.PhoneNumberType;
+import de.symeda.sormas.api.person.Sex;
 import de.symeda.sormas.api.symptoms.SymptomState;
+import de.symeda.sormas.api.systemconfiguration.SystemConfigurationCategoryReferenceDto;
+import de.symeda.sormas.api.systemconfiguration.SystemConfigurationValueDto;
+import de.symeda.sormas.api.utils.DataHelper;
 import de.symeda.sormas.api.utils.YesNoUnknown;
 import de.symeda.sormas.api.vaccination.VaccinationDto;
 import de.symeda.sormas.backend.AbstractBeanTest;
@@ -51,6 +70,9 @@ import de.symeda.sormas.backend.common.ConfigFacadeEjb;
 import de.symeda.sormas.backend.customizableenum.CustomizableEnumValue;
 import de.symeda.sormas.backend.customizablefield.CustomizableFieldMetadataFacadeEjb;
 import de.symeda.sormas.backend.customizablefield.CustomizableFieldValueFacadeEjb;
+import de.symeda.sormas.backend.patch.EqualValueOverrideHelper;
+import de.symeda.sormas.backend.systemconfiguration.SystemConfigurationCategory;
+import de.symeda.sormas.backend.systemconfiguration.SystemConfigurationCategoryService;
 
 class DataPatcherImplTest extends AbstractBeanTest {
 
@@ -723,6 +745,51 @@ class DataPatcherImplTest extends AbstractBeanTest {
 		Assertions.assertAll(
 			() -> Assertions.assertTrue(response.getFailures().isEmpty(), "FORBIDDEN_VALUE_OVERRIDE must not fire for same-day dates"),
 			() -> Assertions.assertTrue(response.isApplied()));
+	}
+
+	@Test
+	void patch_ifNotAlreadyPresent_equalValueOverrideConfiguredForType_realSystemConfigurationAllowsOverride() {
+		// PREPARE
+		CaseDataDto originalCase = creator.createUnclassifiedCase(Disease.PERTUSSIS);
+		originalCase.getEpiData().setExposureDetailsKnown(YesNoUnknown.UNKNOWN);
+		getCaseFacade().save(originalCase);
+
+		setAllowedEqualityValueOverride("YesNoUnknown___UNKNOWN");
+
+		CaseDataPatchRequest request =
+			new CaseDataPatchRequest().setCaseUuid(originalCase.getUuid()).setPatchDictionary(Map.of("EpiData.exposureDetailsKnown", "YES"));
+
+		// EXECUTE
+		DataPatchResponse response = victim().patch(request);
+
+		// CHECK
+		CaseDataDto actualCase = getCaseFacade().getByUuid(originalCase.getUuid());
+		Assertions.assertAll(
+			() -> Assertions.assertTrue(response.getFailures().isEmpty(), "Failures: " + response.getFailures()),
+			() -> Assertions.assertTrue(response.isApplied()),
+			() -> Assertions.assertEquals(YesNoUnknown.YES, actualCase.getEpiData().getExposureDetailsKnown()));
+	}
+
+	private void setAllowedEqualityValueOverride(String overridableValue) {
+		SystemConfigurationCategory category;
+		try {
+			category = getSystemConfigurationCategoryService().getDefaultCategory();
+		} catch (IllegalStateException e) {
+			category = new SystemConfigurationCategory();
+			category.setUuid(DataHelper.createUuid());
+			category.setName(SystemConfigurationCategoryService.DEFAULT_CATEGORY_NAME);
+			getSystemConfigurationCategoryService().ensurePersisted(category);
+		}
+
+		SystemConfigurationValueDto configValue = new SystemConfigurationValueDto();
+
+		configValue.setUuid(DataHelper.createUuid());
+		configValue.setKey(EqualValueOverrideHelper.ALLOWED_EQUALITY_VALUE_OVERRIDE_KEY);
+		configValue.setValue(overridableValue);
+		configValue.setEncrypt(false);
+		configValue.setCategory(new SystemConfigurationCategoryReferenceDto(category.getUuid()));
+
+		getSystemConfigurationValueFacade().save(configValue);
 	}
 
 	@Test


### PR DESCRIPTION

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #14123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selectively allowing certain value overrides during patching.
  * Introduced configuration-based matching for exact or type-prefixed values.

* **Bug Fixes**
  * Patch updates now preserve existing values unless an override is explicitly allowed.
  * Improved error reporting when a value override is rejected, including both current and incoming values.

* **Tests**
  * Added coverage for override configuration scenarios and successful patch application when overrides are permitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->