### PR TITLE
#14007 - Add disease details to quick immunization creation

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/immunization/ImmunizationListCriteria.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/immunization/ImmunizationListCriteria.java
@@ -8,11 +8,13 @@ public class ImmunizationListCriteria extends BaseCriteria {
 
 	private final PersonReferenceDto personReferenceDto;
 	private final Disease disease;
+	private final String diseaseDetails;
 
 	public static class Builder {
 
 		private final PersonReferenceDto personReferenceDto;
 		private Disease disease;
+		private String diseaseDetails;
 
 		public Builder(PersonReferenceDto personReferenceDto) {
 			this.personReferenceDto = personReferenceDto;
@@ -20,6 +22,11 @@ public class ImmunizationListCriteria extends BaseCriteria {
 
 		public Builder withDisease(Disease disease) {
 			this.disease = disease;
+			return this;
+		}
+
+		public Builder withDiseaseDetails(String diseaseDetails) {
+			this.diseaseDetails = diseaseDetails;
 			return this;
 		}
 
@@ -31,6 +38,7 @@ public class ImmunizationListCriteria extends BaseCriteria {
 	private ImmunizationListCriteria(Builder builder) {
 		this.personReferenceDto = builder.personReferenceDto;
 		this.disease = builder.disease;
+		this.diseaseDetails = builder.diseaseDetails;
 	}
 
 	public PersonReferenceDto getPerson() {
@@ -39,5 +47,9 @@ public class ImmunizationListCriteria extends BaseCriteria {
 
 	public Disease getDisease() {
 		return disease;
+	}
+
+	public String getDiseaseDetails() {
+		return diseaseDetails;
 	}
 }

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseDataView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseDataView.java
@@ -204,7 +204,9 @@ public class CaseDataView extends AbstractCaseView implements HasName {
 				.isPropertyValueTrue(FeatureType.IMMUNIZATION_MANAGEMENT, FeatureTypeProperty.REDUCED)) {
 				layout.addSidePanelComponent(new SideComponentLayout(new ImmunizationListComponent(() -> {
 					CaseDataDto refreshedCase = FacadeProvider.getCaseFacade().getCaseDataByUuid(getCaseRef().getUuid());
-					return new ImmunizationListCriteria.Builder(refreshedCase.getPerson()).withDisease(refreshedCase.getDisease()).build();
+					return new ImmunizationListCriteria.Builder(refreshedCase.getPerson()).withDisease(refreshedCase.getDisease())
+						.withDiseaseDetails(refreshedCase.getDiseaseDetails())
+						.build();
 				}, null, this::showUnsavedChangesPopup, isEditAllowed, vaccinationStatusPanel, SormasUI::refreshView)), IMMUNIZATION_LOC);
 			} else {
 				layout.addSidePanelComponent(new SideComponentLayout(new VaccinationListComponent(() -> {

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/ContactDataView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/ContactDataView.java
@@ -277,11 +277,15 @@ public class ContactDataView extends AbstractContactView implements HasName {
 				layout.addSidePanelComponent(new SideComponentLayout(new ImmunizationListComponent(() -> {
 					ContactDto refreshedContact = FacadeProvider.getContactFacade().getByUuid(getContactRef().getUuid());
 					Disease criteriaDisease = refreshedContact.getDisease();
+					String criteriaDiseaseDetails = refreshedContact.getDiseaseDetails();
 					if (criteriaDisease == null && refreshedContact.getCaze() != null) {
 						CaseDataDto refreshedCase = FacadeProvider.getCaseFacade().getCaseDataByUuid(refreshedContact.getCaze().getUuid());
 						criteriaDisease = refreshedCase != null ? refreshedCase.getDisease() : null;
+						criteriaDiseaseDetails = refreshedCase != null ? refreshedCase.getDiseaseDetails() : null;
 					}
-					return new ImmunizationListCriteria.Builder(refreshedContact.getPerson()).withDisease(criteriaDisease).build();
+					return new ImmunizationListCriteria.Builder(refreshedContact.getPerson()).withDisease(criteriaDisease)
+						.withDiseaseDetails(criteriaDiseaseDetails)
+						.build();
 				}, null, this::showUnsavedChangesPopup, editAllowed, vaccinationStatusPanel, SormasUI::refreshView)), IMMUNIZATION_LOC);
 			} else {
 				layout.addSidePanelComponent(new SideComponentLayout(new VaccinationListComponent(() -> {

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventParticipantDataView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventParticipantDataView.java
@@ -188,6 +188,7 @@ public class EventParticipantDataView extends AbstractEventParticipantView imple
 					new SideComponentLayout(
 						new ImmunizationListComponent(
 							() -> new ImmunizationListCriteria.Builder(eventParticipant.getPerson().toReference()).withDisease(event.getDisease())
+								.withDiseaseDetails(event.getDiseaseDetails())
 								.build(),
 							null,
 							this::showUnsavedChangesPopup,

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/immunization/ImmunizationController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/immunization/ImmunizationController.java
@@ -63,11 +63,19 @@ public class ImmunizationController {
 	}
 
 	public void create(PersonReferenceDto person, Disease disease) {
-		create(person, disease, null);
+		create(person, disease, null, null);
 	}
 
 	public void create(PersonReferenceDto person, Disease disease, Runnable savedCallback) {
-		CommitDiscardWrapperComponent<?> createComponent = getImmunizationCreateComponent(person, disease, savedCallback);
+		create(person, disease, null, savedCallback);
+	}
+
+	public void create(PersonReferenceDto person, Disease disease, String diseaseDetails) {
+		create(person, disease, diseaseDetails, null);
+	}
+
+	public void create(PersonReferenceDto person, Disease disease, String diseaseDetails, Runnable savedCallback) {
+		CommitDiscardWrapperComponent<?> createComponent = getImmunizationCreateComponent(person, disease, diseaseDetails, savedCallback);
 		if (createComponent != null) {
 			VaadinUiUtil.showModalPopupWindow(createComponent, I18nProperties.getString(Strings.headingCreateNewImmunization));
 		}
@@ -76,6 +84,7 @@ public class ImmunizationController {
 	private CommitDiscardWrapperComponent<QuickImmunizationCreationForm> buildQuickCreateComponent(
 		PersonReferenceDto person,
 		Disease disease,
+		String diseaseDetails,
 		Runnable savedCallback) {
 
 		UserProvider currentUserProvider = UiUtil.getCurrentUserProvider();
@@ -87,6 +96,7 @@ public class ImmunizationController {
 
 		ImmunizationDto immunization = ImmunizationDto.build(person);
 		immunization.setDisease(disease);
+		immunization.setDiseaseDetails(diseaseDetails);
 		immunization.setReportingUser(currentUserProvider.getUserReference());
 
 		UserDto currentUser = currentUserProvider.getUser();
@@ -201,10 +211,11 @@ public class ImmunizationController {
 	private CommitDiscardWrapperComponent<?> getImmunizationCreateComponent(
 		PersonReferenceDto personReferenceDto,
 		Disease disease,
+		String diseaseDetails,
 		Runnable savedCallback) {
 
 		if (FacadeProvider.getImmunizationFacade().isUseQuickImmunizationCreation()) {
-			return buildQuickCreateComponent(personReferenceDto, disease, savedCallback);
+			return buildQuickCreateComponent(personReferenceDto, disease, diseaseDetails, savedCallback);
 		}
 
 		UserProvider currentUserProvider = UiUtil.getCurrentUserProvider();
@@ -212,6 +223,7 @@ public class ImmunizationController {
 			ImmunizationCreationForm createForm = new ImmunizationCreationForm(personReferenceDto, disease);
 			ImmunizationDto immunization = ImmunizationDto.build(personReferenceDto);
 			immunization.setDisease(disease);
+			immunization.setDiseaseDetails(diseaseDetails);
 			immunization.setReportingUser(currentUserProvider.getUserReference());
 			createForm.setValue(immunization);
 			final CommitDiscardWrapperComponent<ImmunizationCreationForm> viewComponent = new CommitDiscardWrapperComponent<>(

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/immunization/immunizationlink/ImmunizationListComponent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/immunization/immunizationlink/ImmunizationListComponent.java
@@ -46,7 +46,11 @@ public class ImmunizationListComponent extends SideComponent {
 			addCreateButton(I18nProperties.getCaption(Captions.immunizationNewImmunization), () -> {
 				ImmunizationListCriteria immunizationListCriteria = criteriaSupplier.get();
 				ControllerProvider.getImmunizationController()
-					.create(immunizationListCriteria.getPerson(), immunizationListCriteria.getDisease(), quickSavedCallback);
+					.create(
+						immunizationListCriteria.getPerson(),
+						immunizationListCriteria.getDisease(),
+						immunizationListCriteria.getDiseaseDetails(),
+						quickSavedCallback);
 			}, UserRight.IMMUNIZATION_CREATE);
 		}
 


### PR DESCRIPTION
Fixes #14007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Immunization filtering and creation now support an additional disease details field.
  * Case, contact, and event participant views now pass disease details into immunization-related actions for better matching.
* **Bug Fixes**
  * Improved consistency when creating immunizations from linked records, ensuring disease details are carried through where available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->