### PR TITLE
Fixed the active and readonly boolean fields as string representation.

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/customizablefield/CustomizableFieldsGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/customizablefield/CustomizableFieldsGrid.java
@@ -24,6 +24,7 @@ import de.symeda.sormas.api.customizablefield.CustomizableFieldMetadataDto;
 import de.symeda.sormas.api.i18n.Captions;
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.ui.ControllerProvider;
+import de.symeda.sormas.ui.utils.BooleanRenderer;
 import de.symeda.sormas.ui.utils.FilteredGrid;
 import de.symeda.sormas.ui.utils.ShowDetailsListener;
 
@@ -31,65 +32,71 @@ import de.symeda.sormas.ui.utils.ShowDetailsListener;
  * Grid for displaying and managing customizable field metadata.
  */
 @SuppressWarnings({
-    "java:S110", // suppress sonar too many parents warning
-    "java:S2160" // suppress missing equals
+	"java:S110", // suppress sonar too many parents warning
+	"java:S2160" // suppress missing equals
 })
 public class CustomizableFieldsGrid extends FilteredGrid<CustomizableFieldMetadataDto, CustomizableFieldMetadataCriteria> {
 
-    private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
-    private static final String CLONE_COLUMN_ID = "clone";
-    private static final String TOGGLE_ACTIVE_COLUMN_ID = "toggleActive";
-    private static final String DELETE_COLUMN_ID = "delete";
+	private static final String CLONE_COLUMN_ID = "clone";
+	private static final String TOGGLE_ACTIVE_COLUMN_ID = "toggleActive";
+	private static final String DELETE_COLUMN_ID = "delete";
 
-    public CustomizableFieldsGrid(CustomizableFieldMetadataCriteria criteria) {
+	public CustomizableFieldsGrid(CustomizableFieldMetadataCriteria criteria) {
 
-        super(CustomizableFieldMetadataDto.class);
-        setSizeFull();
+		super(CustomizableFieldMetadataDto.class);
+		setSizeFull();
 
-        setLazyDataProvider(
-            FacadeProvider.getCustomizableFieldMetadataFacade()::getIndexList,
-            FacadeProvider.getCustomizableFieldMetadataFacade()::count);
-        setCriteria(criteria);
+		setLazyDataProvider(
+			FacadeProvider.getCustomizableFieldMetadataFacade()::getIndexList,
+			FacadeProvider.getCustomizableFieldMetadataFacade()::count);
+		setCriteria(criteria);
 
-        setColumns(
-            CustomizableFieldMetadataDto.NAME,
-            CustomizableFieldMetadataDto.CONTEXT_CLASS,
-            CustomizableFieldMetadataDto.UI_GROUP,
-            CustomizableFieldMetadataDto.FIELD_TYPE,
-            CustomizableFieldMetadataDto.ACTIVE,
-            CustomizableFieldMetadataDto.READ_ONLY);
+		setColumns(
+			CustomizableFieldMetadataDto.NAME,
+			CustomizableFieldMetadataDto.CONTEXT_CLASS,
+			CustomizableFieldMetadataDto.UI_GROUP,
+			CustomizableFieldMetadataDto.FIELD_TYPE,
+			CustomizableFieldMetadataDto.ACTIVE,
+			CustomizableFieldMetadataDto.READ_ONLY);
 
-        addEditColumn(e -> ControllerProvider.getCustomizableFieldsController().editField(e.getUuid()));
+		((Column<CustomizableFieldMetadataDto, Boolean>) getColumn(CustomizableFieldMetadataDto.READ_ONLY)).setRenderer(new BooleanRenderer());
+		((Column<CustomizableFieldMetadataDto, Boolean>) getColumn(CustomizableFieldMetadataDto.ACTIVE)).setRenderer(new BooleanRenderer());
 
-        addColumn(e -> VaadinIcons.COPY.getHtml(), new HtmlRenderer()).setId(CLONE_COLUMN_ID)
-            .setCaption(I18nProperties.getCaption(Captions.actionClone))
-            .setSortable(false)
-            .setWidth(40);
+		addEditColumn(e -> ControllerProvider.getCustomizableFieldsController().editField(e.getUuid()));
 
-        addColumn(e -> e.isActive() ? VaadinIcons.CLOSE.getHtml() : VaadinIcons.CHECK.getHtml(), new HtmlRenderer()).setId(TOGGLE_ACTIVE_COLUMN_ID)
-            .setCaption(I18nProperties.getCaption(Captions.actionEnable) + "/" + I18nProperties.getCaption(Captions.actionDisable))
-            .setSortable(false)
-            .setWidth(55);
+		addColumn(e -> VaadinIcons.COPY.getHtml(), new HtmlRenderer()).setId(CLONE_COLUMN_ID)
+			.setCaption(I18nProperties.getCaption(Captions.actionClone))
+			.setSortable(false)
+			.setWidth(40);
 
-        addColumn(e -> VaadinIcons.TRASH.getHtml(), new HtmlRenderer()).setId(DELETE_COLUMN_ID)
-            .setCaption(I18nProperties.getCaption(Captions.actionDelete))
-            .setSortable(false)
-            .setWidth(40);
+		addColumn(e -> e.isActive() ? VaadinIcons.CLOSE.getHtml() : VaadinIcons.CHECK.getHtml(), new HtmlRenderer()).setId(TOGGLE_ACTIVE_COLUMN_ID)
+			.setCaption(I18nProperties.getCaption(Captions.actionEnable) + "/" + I18nProperties.getCaption(Captions.actionDisable))
+			.setSortable(false)
+			.setWidth(55);
 
-        addItemClickListener(
-            new ShowDetailsListener<>(CLONE_COLUMN_ID, false, e -> ControllerProvider.getCustomizableFieldsController().cloneField(e)));
-        addItemClickListener(
-            new ShowDetailsListener<>(TOGGLE_ACTIVE_COLUMN_ID, false, e -> ControllerProvider.getCustomizableFieldsController().toggleActive(e)));
-        addItemClickListener(
-            new ShowDetailsListener<>(DELETE_COLUMN_ID, false, e -> ControllerProvider.getCustomizableFieldsController().deleteField(e.getUuid(), this)));
+		addColumn(e -> VaadinIcons.TRASH.getHtml(), new HtmlRenderer()).setId(DELETE_COLUMN_ID)
+			.setCaption(I18nProperties.getCaption(Captions.actionDelete))
+			.setSortable(false)
+			.setWidth(40);
 
-        for (Column<?, ?> column : getColumns()) {
-            column.setCaption(I18nProperties.getPrefixCaption(CustomizableFieldMetadataDto.I18N_PREFIX, column.getId(), column.getCaption()));
-        }
-    }
+		addItemClickListener(
+			new ShowDetailsListener<>(CLONE_COLUMN_ID, false, e -> ControllerProvider.getCustomizableFieldsController().cloneField(e)));
+		addItemClickListener(
+			new ShowDetailsListener<>(TOGGLE_ACTIVE_COLUMN_ID, false, e -> ControllerProvider.getCustomizableFieldsController().toggleActive(e)));
+		addItemClickListener(
+			new ShowDetailsListener<>(
+				DELETE_COLUMN_ID,
+				false,
+				e -> ControllerProvider.getCustomizableFieldsController().deleteField(e.getUuid(), this)));
 
-    public void reload() {
-        getDataProvider().refreshAll();
-    }
+		for (Column<?, ?> column : getColumns()) {
+			column.setCaption(I18nProperties.getPrefixCaption(CustomizableFieldMetadataDto.I18N_PREFIX, column.getId(), column.getCaption()));
+		}
+	}
+
+	public void reload() {
+		getDataProvider().refreshAll();
+	}
 }

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/AbstractContactGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/AbstractContactGrid.java
@@ -47,6 +47,7 @@ import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.ui.ControllerProvider;
 import de.symeda.sormas.ui.UiUtil;
 import de.symeda.sormas.ui.ViewModelProviders;
+import de.symeda.sormas.ui.utils.BooleanRenderer;
 import de.symeda.sormas.ui.utils.CssStyles;
 import de.symeda.sormas.ui.utils.DateFormatHelper;
 import de.symeda.sormas.ui.utils.FieldAccessColumnStyleGenerator;
@@ -184,6 +185,7 @@ public abstract class AbstractContactGrid<IndexDto extends ContactIndexDto> exte
 		((Column<ContactIndexDto, String>) getColumn(ContactIndexDto.UUID)).setRenderer(new UuidRenderer());
 		((Column<ContactIndexDto, String>) getColumn(ContactIndexDto.PERSON_UUID)).setRenderer(new UuidRenderer());
 		((Column<ContactIndexDto, Date>) getColumn(ContactIndexDto.FOLLOW_UP_UNTIL)).setRenderer(new DateRenderer(DateFormatHelper.getDateFormat()));
+		((Column<ContactIndexDto, Boolean>) getColumn(ContactIndexDto.PROPHYLAXIS_PRESCRIBED)).setRenderer(new BooleanRenderer());
 
 		if (!FacadeProvider.getConfigFacade().isExternalJournalActive()) {
 			getColumn(ContactIndexDto.SYMPTOM_JOURNAL_STATUS).setHidden(true);


### PR DESCRIPTION
The active and readonly fields now shows "Yes" or "No" instead of "true" or "false".

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how boolean status values are displayed in grids by using a dedicated boolean renderer for clearer, more consistent visibility.
  * Updated the customizable fields grid for the read-only and active columns.
  * Updated the contact grid to render prophylaxis prescribed as a boolean in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->