### PR TITLE
Fix sample-type visibility and AST commit crash (#14018, #14156, #14124)

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/sample/SampleMaterial.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/sample/SampleMaterial.java
@@ -340,7 +340,7 @@ public enum SampleMaterial {
 	PLEURAL_FLUID,
 
 	// Re-activated for RSV new samples (#14023): the RSV specimen requirements list Nasopharyngeal lavage.
-	// No canonical SNOMED-CT code on the specimen sheet, so its SNOMED export stays null. 
+	// No canonical SNOMED-CT code on the specimen sheet, so its SNOMED export stays null.
 	@Diseases(value = {
 		Disease.RESPIRATORY_SYNCYTIAL_VIRUS })
 	NASOPHARYNGEAL_LAVAGE,
@@ -367,11 +367,10 @@ public enum SampleMaterial {
 		Disease.SHIGELLOSIS }, hide = true)
 	AMNIOTIC_FLUID,
 
-	@Diseases(value = {
-		Disease.RESPIRATORY_SYNCYTIAL_VIRUS,
-		Disease.GIARDIASIS }, hide = true)
+	// Clinical Sample (Other) is offered for every disease (#14018) — no @Diseases means "visible for all".
 	CLINICAL_SAMPLE,
 
+	// Lux hide lifted so Peritoneal fluid shows for IPI on Luxembourg servers (#14156).
 	@Diseases(value = {
 		Disease.RESPIRATORY_SYNCYTIAL_VIRUS,
 		Disease.INVASIVE_MENINGOCOCCAL_INFECTION,
@@ -381,8 +380,6 @@ public enum SampleMaterial {
 		Disease.MALARIA,
 		Disease.DENGUE,
 		Disease.SALMONELLOSIS }, hide = true)
-	@HideForCountries(countries = {
-		CountryHelper.COUNTRY_CODE_LUXEMBOURG })
 	PERITONEAL_FLUID,
 
 	@Diseases(value = {

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/diseasesection/ImiSectionComponent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/diseasesection/ImiSectionComponent.java
@@ -152,5 +152,4 @@ public class ImiSectionComponent extends AbstractDiseaseSectionComponent {
 			drugSusceptibilityField = null;
 		}
 	}
-
 }

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/therapy/DrugSusceptibilityForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/therapy/DrugSusceptibilityForm.java
@@ -348,6 +348,14 @@ public class DrugSusceptibilityForm extends AbstractEditForm<DrugSusceptibilityD
 		super.markAsDirty();
 	}
 
+	@Override
+	public void commit() {
+		if (getValue() == null) {
+			return;
+		}
+		super.commit();
+	}
+
 	public void forceUpdateDrugSusceptibilityFields() {
 		final DrugSusceptibilityDto drugSusceptibilityDto = getValue();
 		if (drugSusceptibilityDto == null) {

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/therapy/DrugSusceptibilityForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/therapy/DrugSusceptibilityForm.java
@@ -350,6 +350,9 @@ public class DrugSusceptibilityForm extends AbstractEditForm<DrugSusceptibilityD
 
 	@Override
 	public void commit() {
+		// When no DrugSusceptibilityDto is bound (e.g. after a disease-section swap nulls it), the internal
+		// field group has no item datasource, so committing its always-bound drug fields would throw
+		// "Property amikacinMic not bound to datasource" (#14124). Nothing to write, so skip the commit.
 		if (getValue() == null) {
 			return;
 		}


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #14018 #14156 #14124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated sample/material visibility rules so “Clinical Sample / Other” is available for all diseases and peritoneal fluid is no longer hidden for Luxembourg.
  * Prevented an empty drug susceptibility form from being saved when no value is present, reducing form-related errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->