### PR TITLE
Corrected the travel purpose visibility to Dengue.

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/exposure/ExposureForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/exposure/ExposureForm.java
@@ -710,10 +710,6 @@ public class ExposureForm extends AbstractEditForm<ExposureDto> {
 
 			boolean isMalariaCaseTraveled = subSettings != null && disease == Disease.MALARIA && hasTravelledAbroad;
 			prophylaxisAdherenceField.setVisible(isMalariaCaseTraveled);
-			travelPurposeField.setVisible(hasTravelledAbroad && (disease == Disease.MALARIA || disease == Disease.DENGUE));
-			travelPurposeField.setValue(travelPurpose);
-			travelPurposeDetailsField.setVisible(travelPurpose == TravelPurpose.OTHER);
-			travelPurposeDetailsField.setValue(travelPurposeDetails);
 			// If the Malaria-effected person traveled abroad, show the prophylaxis adherence and travel purpose fields
 			if (isMalariaCaseTraveled) {
 				if (prophylaxisAdherence != null) {
@@ -727,6 +723,20 @@ public class ExposureForm extends AbstractEditForm<ExposureDto> {
 				prophylaxisAdherenceField.setValue(null);
 				prophylaxisAdherenceDetailsField.setValue(null);
 				prophylaxisAdherenceDetailsField.setVisible(false);
+			}
+			// Travel purpose is visible to abroad travelers of Malaria and Dengue
+			boolean isTravelPurposeVisible = hasTravelledAbroad && (disease == Disease.MALARIA || disease == Disease.DENGUE);
+			travelPurposeField.setVisible(isTravelPurposeVisible);
+			if (isTravelPurposeVisible) {
+				travelPurposeField.setValue(travelPurpose);
+				travelPurposeDetailsField.setVisible(travelPurpose == TravelPurpose.OTHER);
+				if (travelPurposeDetails != null) {
+					travelPurposeDetailsField.setValue(travelPurposeDetails);
+				}
+			} else {
+				travelPurposeField.setValue(null);
+				travelPurposeDetailsField.setValue(null);
+				travelPurposeDetailsField.setVisible(false);
 			}
 
 			boolean isSexualActivity = subSettings != null && subSettings.contains(ExposureSubSetting.SEXUAL_ACTIVITY);

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/exposure/ExposureForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/exposure/ExposureForm.java
@@ -423,9 +423,11 @@ public class ExposureForm extends AbstractEditForm<ExposureDto> {
 			boolean containsOther = selectedSubSettings != null && selectedSubSettings.contains(ExposureSubSetting.OTHER);
 			subSettingsDetailsField.setVisible(containsOther);
 			// prophylaxis is allowed only for Malaria abroad travelers, not all diseases
-			boolean isProphylaxis =
-				selectedSubSettings != null && disease == Disease.MALARIA && selectedSubSettings.contains(ExposureSubSetting.TRAVELED_ABROAD);
-			setVisibleClear(isProphylaxis, ExposureDto.PROPHYLAXIS_ADHERENCE, ExposureDto.TRAVEL_PURPOSE);
+			boolean hasTravelledAbroad = selectedSubSettings != null && selectedSubSettings.contains(ExposureSubSetting.TRAVELED_ABROAD);
+			setVisibleClear(hasTravelledAbroad && disease == Disease.MALARIA, ExposureDto.PROPHYLAXIS_ADHERENCE);
+
+			// Travel purpose is visible to aboard travelers of Malaria and Dengue
+			setVisibleClear(hasTravelledAbroad && (disease == Disease.MALARIA || disease == Disease.DENGUE), ExposureDto.TRAVEL_PURPOSE);
 			boolean isSexualActivity = selectedSubSettings != null && selectedSubSettings.contains(ExposureSubSetting.SEXUAL_ACTIVITY);
 			setVisibleClear(isSexualActivity, ExposureDto.SEXUAL_CONTACT);
 
@@ -704,10 +706,14 @@ public class ExposureForm extends AbstractEditForm<ExposureDto> {
 				subSettingsDetailsField.setValue(subSettingDetails);
 			}
 
-			boolean isMalariaCaseTraveled =
-				subSettings != null && disease == Disease.MALARIA && subSettings.contains(ExposureSubSetting.TRAVELED_ABROAD);
+			boolean hasTravelledAbroad = subSettings != null && subSettings.contains(ExposureSubSetting.TRAVELED_ABROAD);
+
+			boolean isMalariaCaseTraveled = subSettings != null && disease == Disease.MALARIA && hasTravelledAbroad;
 			prophylaxisAdherenceField.setVisible(isMalariaCaseTraveled);
-			travelPurposeField.setVisible(isMalariaCaseTraveled);
+			travelPurposeField.setVisible(hasTravelledAbroad && (disease == Disease.MALARIA || disease == Disease.DENGUE));
+			travelPurposeField.setValue(travelPurpose);
+			travelPurposeDetailsField.setVisible(travelPurpose == TravelPurpose.OTHER);
+			travelPurposeDetailsField.setValue(travelPurposeDetails);
 			// If the Malaria-effected person traveled abroad, show the prophylaxis adherence and travel purpose fields
 			if (isMalariaCaseTraveled) {
 				if (prophylaxisAdherence != null) {
@@ -717,21 +723,10 @@ public class ExposureForm extends AbstractEditForm<ExposureDto> {
 				if (prophylaxisAdherenceDetails != null) {
 					prophylaxisAdherenceDetailsField.setValue(prophylaxisAdherenceDetails);
 				}
-
-				if (travelPurpose != null) {
-					travelPurposeField.setValue(travelPurpose);
-				}
-				travelPurposeDetailsField.setVisible(travelPurpose == TravelPurpose.OTHER);
-				if (travelPurposeDetails != null) {
-					travelPurposeDetailsField.setValue(travelPurposeDetails);
-				}
 			} else {
 				prophylaxisAdherenceField.setValue(null);
 				prophylaxisAdherenceDetailsField.setValue(null);
 				prophylaxisAdherenceDetailsField.setVisible(false);
-				travelPurposeField.setValue(null);
-				travelPurposeDetailsField.setValue(null);
-				travelPurposeDetailsField.setVisible(false);
 			}
 
 			boolean isSexualActivity = subSettings != null && subSettings.contains(ExposureSubSetting.SEXUAL_ACTIVITY);


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected exposure form field visibility so travel-related details appear appropriately based on the selected disease and whether travel abroad applies.
  * Improved record restoration to ensure travel-purpose information is retained and shown when relevant during edit/reopen flows.
  * Prevented unintended clearing of non-relevant fields when the scenario is not malaria-related travel exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->