### PR TITLE
#14144 - Added cause of death to external message

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/ExternalMessageDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/ExternalMessageDto.java
@@ -39,6 +39,7 @@ import de.symeda.sormas.api.feature.FeatureType;
 import de.symeda.sormas.api.i18n.Validations;
 import de.symeda.sormas.api.infrastructure.country.CountryReferenceDto;
 import de.symeda.sormas.api.infrastructure.facility.FacilityReferenceDto;
+import de.symeda.sormas.api.person.CauseOfDeath;
 import de.symeda.sormas.api.person.PhoneNumberType;
 import de.symeda.sormas.api.person.PresentCondition;
 import de.symeda.sormas.api.person.Sex;
@@ -49,6 +50,7 @@ import de.symeda.sormas.api.utils.DataHelper;
 import de.symeda.sormas.api.utils.DependingOnFeatureType;
 import de.symeda.sormas.api.utils.FieldConstraints;
 import de.symeda.sormas.api.utils.HideForCountriesExcept;
+import de.symeda.sormas.api.utils.SensitiveData;
 import de.symeda.sormas.api.utils.YesNoUnknown;
 
 @AuditedClass
@@ -198,6 +200,11 @@ public class ExternalMessageDto extends SormasToSormasShareableDto {
 	private Date treatmentStartedDate;
 	private Date diagnosticDate;
 	private Date deceasedDate;
+	private CauseOfDeath causeOfDeath;
+	private Disease causeOfDeathDisease;
+	@SensitiveData
+	@Size(max = FieldConstraints.CHARACTER_LIMIT_DEFAULT, message = Validations.textTooLong)
+	private String causeOfDeathDetails;
 
 	@AuditIncludeProperty
 	private List<SampleReportDto> sampleReports;
@@ -895,6 +902,30 @@ public class ExternalMessageDto extends SormasToSormasShareableDto {
 
 	public void setDeceasedDate(Date deceasedDate) {
 		this.deceasedDate = deceasedDate;
+	}
+
+	public CauseOfDeath getCauseOfDeath() {
+		return causeOfDeath;
+	}
+
+	public void setCauseOfDeath(CauseOfDeath causeOfDeath) {
+		this.causeOfDeath = causeOfDeath;
+	}
+
+	public String getCauseOfDeathDetails() {
+		return causeOfDeathDetails;
+	}
+
+	public void setCauseOfDeathDetails(String causeOfDeathDetails) {
+		this.causeOfDeathDetails = causeOfDeathDetails;
+	}
+
+	public Disease getCauseOfDeathDisease() {
+		return causeOfDeathDisease;
+	}
+
+	public void setCauseOfDeathDisease(Disease causeOfDeathDisease) {
+		this.causeOfDeathDisease = causeOfDeathDisease;
 	}
 
 	public RadiographyCompatibility getRadiographyCompatibility() {

--- a/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/processing/ExternalMessageMapper.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/processing/ExternalMessageMapper.java
@@ -91,6 +91,17 @@ public final class ExternalMessageMapper {
 					externalMessage.getPersonPresentCondition(),
 					PersonDto.PRESENT_CONDITION),
 				Mapping.of(person::setDeathDate, person.getDeathDate(), externalMessage.getDeceasedDate(), PersonDto.DEATH_DATE),
+				Mapping.of(person::setCauseOfDeath, person.getCauseOfDeath(), externalMessage.getCauseOfDeath(), PersonDto.CAUSE_OF_DEATH),
+				Mapping.of(
+					person::setCauseOfDeathDetails,
+					person.getCauseOfDeathDetails(),
+					externalMessage.getCauseOfDeathDetails(),
+					PersonDto.CAUSE_OF_DEATH_DETAILS),
+				Mapping.of(
+					person::setCauseOfDeathDisease,
+					person.getCauseOfDeathDisease(),
+					externalMessage.getCauseOfDeathDisease(),
+					PersonDto.CAUSE_OF_DEATH_DISEASE),
 				Mapping.of(person::setPhone, person.getPhone(), externalMessage.getPersonPhone(), PersonDto.PERSON_CONTACT_DETAILS),
 				Mapping.of(
 					person::setPhoneNumberType,

--- a/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/processing/ExternalMessageMapper.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/processing/ExternalMessageMapper.java
@@ -369,6 +369,58 @@ public final class ExternalMessageMapper {
 	}
 
 	/**
+	 * Merges additional person data.
+	 * Only non-null values from the external message overwrite existing fields.
+	 * 
+	 * @param person
+	 *            The existing person to update.
+	 * @return A list of changed UI field paths; empty if the person has no address.
+	 */
+	public List<String[]> mergePersonAdditionalInformation(PersonDto person) {
+		if (person == null) {
+			return Collections.emptyList();
+		}
+
+		List<String[]> changedFields = new ArrayList<>();
+
+		if (externalMessage.getPersonPresentCondition() != null) {
+			person.setPresentCondition(externalMessage.getPersonPresentCondition());
+			changedFields.add(
+				new String[] {
+					PersonDto.PRESENT_CONDITION });
+		}
+
+		if (externalMessage.getDeceasedDate() != null) {
+			person.setDeathDate(externalMessage.getDeceasedDate());
+			changedFields.add(
+				new String[] {
+					PersonDto.DEATH_DATE });
+		}
+
+		if (externalMessage.getCauseOfDeath() != null) {
+			person.setCauseOfDeath(externalMessage.getCauseOfDeath());
+			changedFields.add(
+				new String[] {
+					PersonDto.CAUSE_OF_DEATH });
+		}
+
+		if (externalMessage.getCauseOfDeathDisease() != null) {
+			person.setCauseOfDeathDisease(externalMessage.getCauseOfDeathDisease());
+			changedFields.add(
+				new String[] {
+					PersonDto.CAUSE_OF_DEATH_DISEASE });
+		}
+
+		if (externalMessage.getCauseOfDeathDetails() != null) {
+			person.setCauseOfDeathDetails(externalMessage.getCauseOfDeathDetails());
+			changedFields.add(
+				new String[] {
+					PersonDto.CAUSE_OF_DEATH_DETAILS });
+		}
+		return changedFields;
+	}
+
+	/**
 	 * Merges primary phone and email contact details from the external message onto the given person.
 	 * If the incoming value already exists in the list it is promoted to primary and the old primary is demoted;
 	 * otherwise a new primary entry is created and the old primary is demoted.

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/externalmessage/ExternalMessage.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/externalmessage/ExternalMessage.java
@@ -890,6 +890,7 @@ public class ExternalMessage extends AbstractDomainObject {
 		this.causeOfDeath = causeOfDeath;
 	}
 
+	@Column(length = CHARACTER_LIMIT_DEFAULT)
 	public String getCauseOfDeathDetails() {
 		return causeOfDeathDetails;
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/externalmessage/ExternalMessage.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/externalmessage/ExternalMessage.java
@@ -15,12 +15,26 @@
 
 package de.symeda.sormas.backend.externalmessage;
 
-import static de.symeda.sormas.api.utils.FieldConstraints.*;
+import static de.symeda.sormas.api.utils.FieldConstraints.CHARACTER_LIMIT_DEFAULT;
+import static de.symeda.sormas.api.utils.FieldConstraints.CHARACTER_LIMIT_SMALL;
+import static de.symeda.sormas.api.utils.FieldConstraints.CHARACTER_LIMIT_TEXT;
 
 import java.util.Date;
 import java.util.List;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import javax.persistence.Transient;
 
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
@@ -38,6 +52,7 @@ import de.symeda.sormas.api.disease.DiseaseVariantConverter;
 import de.symeda.sormas.api.exposure.ModeOfTransmission;
 import de.symeda.sormas.api.externalmessage.ExternalMessageStatus;
 import de.symeda.sormas.api.externalmessage.ExternalMessageType;
+import de.symeda.sormas.api.person.CauseOfDeath;
 import de.symeda.sormas.api.person.PhoneNumberType;
 import de.symeda.sormas.api.person.PresentCondition;
 import de.symeda.sormas.api.person.Sex;
@@ -169,6 +184,9 @@ public class ExternalMessage extends AbstractDomainObject {
 	private Date treatmentStartedDate;
 	private Date diagnosticDate;
 	private Date deceasedDate;
+	private CauseOfDeath causeOfDeath;
+	private String causeOfDeathDetails;
+	private Disease causeOfDeathDisease;
 
 	private String externalMessageDetails;
 	private String caseComments;
@@ -861,6 +879,32 @@ public class ExternalMessage extends AbstractDomainObject {
 
 	public void setDeceasedDate(Date deceasedDate) {
 		this.deceasedDate = deceasedDate;
+	}
+
+	@Enumerated(EnumType.STRING)
+	public CauseOfDeath getCauseOfDeath() {
+		return causeOfDeath;
+	}
+
+	public void setCauseOfDeath(CauseOfDeath causeOfDeath) {
+		this.causeOfDeath = causeOfDeath;
+	}
+
+	public String getCauseOfDeathDetails() {
+		return causeOfDeathDetails;
+	}
+
+	public void setCauseOfDeathDetails(String causeOfDeathDetails) {
+		this.causeOfDeathDetails = causeOfDeathDetails;
+	}
+
+	@Enumerated(EnumType.STRING)
+	public Disease getCauseOfDeathDisease() {
+		return causeOfDeathDisease;
+	}
+
+	public void setCauseOfDeathDisease(Disease causeOfDeathDisease) {
+		this.causeOfDeathDisease = causeOfDeathDisease;
 	}
 
 	@Enumerated(EnumType.STRING)

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/externalmessage/ExternalMessageFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/externalmessage/ExternalMessageFacadeEjb.java
@@ -252,6 +252,9 @@ public class ExternalMessageFacadeEjb implements ExternalMessageFacade {
 		target.setAdditionalPersonContactDetails(source.getAdditionalPersonContactDetails());
 		target.setAdditionalPersonAddresses(source.getAdditionalPersonAddresses());
 		target.setDeceasedDate(source.getDeceasedDate());
+		target.setCauseOfDeath(source.getCauseOfDeath());
+		target.setCauseOfDeathDetails(source.getCauseOfDeathDetails());
+		target.setCauseOfDeathDisease(source.getCauseOfDeathDisease());
 
 		target.setReportId(source.getReportId());
 		if (source.getAssignee() != null) {
@@ -582,6 +585,9 @@ public class ExternalMessageFacadeEjb implements ExternalMessageFacade {
 		target.setAdditionalPersonContactDetails(source.getAdditionalPersonContactDetails());
 		target.setAdditionalPersonAddresses(source.getAdditionalPersonAddresses());
 		target.setDeceasedDate(source.getDeceasedDate());
+		target.setCauseOfDeath(source.getCauseOfDeath());
+		target.setCauseOfDeathDetails(source.getCauseOfDeathDetails());
+		target.setCauseOfDeathDisease(source.getCauseOfDeathDisease());
 
 		target.setReportId(source.getReportId());
 		if (source.getSampleReports() != null) {

--- a/sormas-backend/src/main/resources/sql/sormas_schema.sql
+++ b/sormas-backend/src/main/resources/sql/sormas_schema.sql
@@ -16723,4 +16723,15 @@ BEGIN
 END $$;
 INSERT INTO schema_version (version_number, comment) VALUES (646, 'Correcting the typos of column names');
 
+-- #14144 - External message cause of death
+
+ALTER TABLE externalmessage ADD COLUMN causeofdeath varchar(255);
+ALTER TABLE externalmessage ADD COLUMN causeofdeathdetails varchar(512);
+ALTER TABLE externalmessage ADD COLUMN causeofdeathdisease varchar(255);
+ALTER TABLE externalmessage_history ADD COLUMN causeofdeath varchar(255);
+ALTER TABLE externalmessage_history ADD COLUMN causeofdeathdetails varchar(512);
+ALTER TABLE externalmessage_history ADD COLUMN causeofdeathdisease varchar(255);
+
+INSERT INTO schema_version (version_number, comment) VALUES (647, '#14144 - External message missing cause of death');
+
 -- *** Insert new sql commands BEFORE this line. Remember to always consider _history tables. ***

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/externalmessage/doctordeclaration/DoctorDeclarationMessageProcessingFlow.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/externalmessage/doctordeclaration/DoctorDeclarationMessageProcessingFlow.java
@@ -411,6 +411,7 @@ public class DoctorDeclarationMessageProcessingFlow extends AbstractDoctorDeclar
 
 		getMapper().mergePersonAddress(person);
 		getMapper().mergePersonContactDetails(person);
+		getMapper().mergePersonAdditionalInformation(person);
 		getMapper().mapGuardianData(person);
 		getMapper().mapOccupationData(person);
 


### PR DESCRIPTION
Fixes #14144

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recording and viewing cause-of-death information in external messages, including cause, disease, and details.
  * This information is now carried through to the related person record and reflected in the user interface.

* **Bug Fixes**
  * Fixed missing transfer of additional person details when processing doctor declaration messages.

* **Chores**
  * Updated the data schema to store the new cause-of-death fields for current and historical records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->