### PR TITLE
FIX: sorting issue with empty-null values

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/ExtendedPostgreSQL94Dialect.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/ExtendedPostgreSQL94Dialect.java
@@ -29,6 +29,7 @@ public class ExtendedPostgreSQL94Dialect extends PostgreSQL94Dialect {
 	public final static String TIMESTAMP_SUBTRACT_14_DAYS = "timestamp_subtract_14_days";
 	public final static String AT_END_OF_DAY = "at_end_of_day";
 	public final static String FULLTEXT_SEARCH = "fulltext_search";
+	public final static String EMPTY_TO_NULL = "empty_to_null";
 
 	public ExtendedPostgreSQL94Dialect() {
 		super();
@@ -59,5 +60,6 @@ public class ExtendedPostgreSQL94Dialect extends PostgreSQL94Dialect {
 			new SQLFunctionTemplate(StandardBasicTypes.DATE, "?1 - interval '" + VaccinationService.REPORT_DATE_RELEVANT_DAYS + " days'"));
 		registerFunction(AT_END_OF_DAY, new SQLFunctionTemplate(StandardBasicTypes.DATE, "?1::date + interval '1 day' - interval '1 microsecond'"));
 		registerFunction(FULLTEXT_SEARCH, new SQLFunctionTemplate(StandardBasicTypes.BOOLEAN, "?1 @@ plainto_tsquery('simple', unaccent(?2))"));
+		registerFunction(EMPTY_TO_NULL, new SQLFunctionTemplate(StandardBasicTypes.STRING, "NULLIF(TRIM(?1), '')"));
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseListCriteriaBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseListCriteriaBuilder.java
@@ -272,7 +272,8 @@ public class CaseListCriteriaBuilder {
 		case ContactIndexDto.SYMPTOM_JOURNAL_STATUS:
 			return Collections.singletonList(joins.getPerson().get(sortProperty.propertyName));
 		case CaseIndexDto.PERSON_NATIONAL_HEALTH_ID:
-			return Collections.singletonList(cb.lower(joins.getPerson().get(Person.NATIONAL_HEALTH_ID)));
+			return Collections.singletonList(
+				cb.lower(cb.function(ExtendedPostgreSQL94Dialect.EMPTY_TO_NULL, String.class, joins.getPerson().get(Person.NATIONAL_HEALTH_ID))));
 		case CaseIndexDto.PERSON_FIRST_NAME:
 			return Collections.singletonList(cb.lower(joins.getPerson().get(Person.FIRST_NAME)));
 		case CaseIndexDto.PERSON_LAST_NAME:

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseListCriteriaBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseListCriteriaBuilder.java
@@ -272,8 +272,7 @@ public class CaseListCriteriaBuilder {
 		case ContactIndexDto.SYMPTOM_JOURNAL_STATUS:
 			return Collections.singletonList(joins.getPerson().get(sortProperty.propertyName));
 		case CaseIndexDto.PERSON_NATIONAL_HEALTH_ID:
-			return Collections.singletonList(
-				cb.lower(cb.function(ExtendedPostgreSQL94Dialect.EMPTY_TO_NULL, String.class, joins.getPerson().get(Person.NATIONAL_HEALTH_ID))));
+			return Collections.singletonList(CriteriaBuilderHelper.lowerAndEmptyToNull(cb, joins.getPerson().get(Person.NATIONAL_HEALTH_ID)));
 		case CaseIndexDto.PERSON_FIRST_NAME:
 			return Collections.singletonList(cb.lower(joins.getPerson().get(Person.FIRST_NAME)));
 		case CaseIndexDto.PERSON_LAST_NAME:
@@ -322,7 +321,7 @@ public class CaseListCriteriaBuilder {
 		case CaseIndexDto.EXTERNAL_TOKEN:
 		case CaseIndexDto.INTERNAL_TOKEN:
 		case CaseIndexDto.CASE_REFERENCE_NUMBER:
-			return Collections.singletonList(cb.lower(caze.get(sortProperty.propertyName)));
+			return Collections.singletonList(CriteriaBuilderHelper.lowerAndEmptyToNull(cb, caze.get(sortProperty.propertyName)));
 		default:
 			throw new IllegalArgumentException(sortProperty.propertyName);
 		}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/CriteriaBuilderHelper.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/CriteriaBuilderHelper.java
@@ -233,6 +233,19 @@ public class CriteriaBuilderHelper {
 				cb.function("date_part", Double.class, cb.literal("epoch"), date2)));
 	}
 
+	/**
+	 * Useful for sorting purposes: to lower case and replace '' (empty string) by NULL.
+	 * 
+	 * @param cb
+	 *            CriteriaBuilder that used to create the expression.
+	 * @param expression
+	 *            field on which the expression will be applied.
+	 * @return changes expression to lower case and replace '' by null.
+	 */
+	public static Expression<String> lowerAndEmptyToNull(CriteriaBuilder cb, Expression<String> expression) {
+		return cb.lower(cb.function(ExtendedPostgreSQL94Dialect.EMPTY_TO_NULL, String.class, expression));
+	}
+
 	public static List<Order> orders(CriteriaBuilder cb, boolean ascending, Expression<?>... expressions) {
 		return Stream.of(expressions).map(e -> ascending ? cb.asc(e) : cb.desc(e)).collect(Collectors.toList());
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
@@ -127,6 +127,7 @@ import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.api.utils.ValidationRuntimeException;
 import de.symeda.sormas.api.utils.fieldaccess.checkers.AnnotationBasedFieldAccessChecker.SpecialAccessCheck;
 import de.symeda.sormas.api.vaccination.VaccinationDto;
+import de.symeda.sormas.backend.ExtendedPostgreSQL94Dialect;
 import de.symeda.sormas.backend.FacadeHelper;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseFacadeEjb;
@@ -1517,7 +1518,8 @@ public class PersonFacadeEjb extends AbstractBaseEjb<Person, PersonDto, PersonIn
 				case PersonIndexDto.POSTAL_CODE:
 				case PersonIndexDto.CITY:
 					Join<Person, Location> location = personQueryContext.getJoins().getAddress();
-					expression = cb.lower(location.get(sortProperty.propertyName));
+					expression =
+						cb.lower(cb.function(ExtendedPostgreSQL94Dialect.EMPTY_TO_NULL, String.class, location.get(sortProperty.propertyName)));
 					break;
 				default:
 					throw new IllegalArgumentException(sortProperty.propertyName);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
@@ -127,7 +127,6 @@ import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.api.utils.ValidationRuntimeException;
 import de.symeda.sormas.api.utils.fieldaccess.checkers.AnnotationBasedFieldAccessChecker.SpecialAccessCheck;
 import de.symeda.sormas.api.vaccination.VaccinationDto;
-import de.symeda.sormas.backend.ExtendedPostgreSQL94Dialect;
 import de.symeda.sormas.backend.FacadeHelper;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseFacadeEjb;
@@ -1518,8 +1517,7 @@ public class PersonFacadeEjb extends AbstractBaseEjb<Person, PersonDto, PersonIn
 				case PersonIndexDto.POSTAL_CODE:
 				case PersonIndexDto.CITY:
 					Join<Person, Location> location = personQueryContext.getJoins().getAddress();
-					expression =
-						cb.lower(cb.function(ExtendedPostgreSQL94Dialect.EMPTY_TO_NULL, String.class, location.get(sortProperty.propertyName)));
+					expression = CriteriaBuilderHelper.lowerAndEmptyToNull(cb, location.get(sortProperty.propertyName));
 					break;
 				default:
 					throw new IllegalArgumentException(sortProperty.propertyName);


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #14147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ordering for address-related fields such as street, house number, postal code, and city.
  * Empty string values are now treated consistently as missing values, resulting in more intuitive and stable sort order.
  * Updated sorting for the national health ID field as well, applying the same empty-to-missing behavior during ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->