### PR TITLE
Display existing samples in sample box for roles without external message rights

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/sampleLink/SampleList.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/sampleLink/SampleList.java
@@ -66,24 +66,16 @@ public class SampleList extends PaginationList<SampleListEntryDto> {
 
 	@Override
 	protected void drawDisplayedEntries() {
-		// Don't do anyting if the user doesn't have the permission to view external messages
-		if (!UiUtil.getUserRights().contains(UserRight.EXTERNAL_MESSAGE_ACCESS)) {
-			return;
-		}
-
-		// Don't do anyting if the user doesn't have the permission to view laboratory messages
-		if (!UiUtil.permitted(UserRight.EXTERNAL_MESSAGE_LABORATORY_VIEW)) {
-			return;
-		}
+		// External message rights are only required for the associated lab messages lookup and button,
+		// not for displaying the samples themselves.
+		final boolean userHasExternalMessageAccess = UiUtil.getUserRights().contains(UserRight.EXTERNAL_MESSAGE_ACCESS)
+			&& UiUtil.permitted(UserRight.EXTERNAL_MESSAGE_LABORATORY_VIEW);
 
 		final boolean userHasSampleEdit = UiUtil.permitted(isEditAllowed, UserRight.SAMPLE_EDIT);
 		final boolean userHasLaboratoryProcessing = UiUtil.permitted(UserRight.EXTERNAL_MESSAGE_LABORATORY_PROCESS);
 
 		for (SampleListEntryDto sample : getDisplayedEntries()) {
 			SampleListEntry listEntry = new SampleListEntry(sample);
-
-			final List<ExternalMessageDto> labMessages =
-				FacadeProvider.getExternalMessageFacade().getForSample(listEntry.getSampleListEntryDto().toReference());
 
 			String sampleUuid = sample.getUuid();
 			if (userHasSampleEdit && userHasLaboratoryProcessing) {
@@ -98,9 +90,13 @@ public class SampleList extends PaginationList<SampleListEntryDto> {
 
 			listEntry.setEnabled(isEditAllowed);
 
-			if (!labMessages.isEmpty()) {
-				listEntry.addAssociatedLabMessagesListener(
-					clickEvent -> ControllerProvider.getExternalMessageController().showLabMessagesSlider(labMessages));
+			if (userHasExternalMessageAccess) {
+				final List<ExternalMessageDto> labMessages =
+					FacadeProvider.getExternalMessageFacade().getForSample(listEntry.getSampleListEntryDto().toReference());
+				if (!labMessages.isEmpty()) {
+					listEntry.addAssociatedLabMessagesListener(
+						clickEvent -> ControllerProvider.getExternalMessageController().showLabMessagesSlider(labMessages));
+				}
 			}
 
 			listLayout.addComponent(listEntry);


### PR DESCRIPTION
…external message rights

drawDisplayedEntries() returned early when the user lacked EXTERNAL_MESSAGE_ACCESS or EXTERNAL_MESSAGE_LABORATORY_VIEW, suppressing all sample rows for roles that have SAMPLE_VIEW but not those external-message rights (e.g. clinician, case supervisor).

Always render the sample rows and gate only the associated lab-message lookup and button on the external-message rights.

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
#14006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Laboratory messages are now loaded and displayed only when the appropriate access rights are available.
  * Prevented unnecessary laboratory-message requests for users without external-message access.
  * Preserved existing sample editing and laboratory-processing permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->