### PR TITLE
Uknown sample material should be expanded to other servers

### DIFF
--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/sample/edit/SampleEditFragment.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/sample/edit/SampleEditFragment.java
@@ -33,7 +33,6 @@ import android.view.View;
 
 import androidx.annotation.Nullable;
 
-import de.symeda.sormas.api.CountryHelper;
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.feature.FeatureType;
 import de.symeda.sormas.api.infrastructure.facility.FacilityDto;
@@ -207,7 +206,6 @@ public class SampleEditFragment extends BaseEditFragment<FragmentSampleEditLayou
 
 	private List<Item> buildSampleMaterialList() {
 
-		final boolean luxembourg = ConfigProvider.isConfiguredServer(CountryHelper.COUNTRY_CODE_LUXEMBOURG);
 		final SampleMaterial currentMaterial = record.getSampleMaterial();
 
 		return DataUtils.getEnumItems(SampleMaterial.class, true, getFieldVisibilityCheckers())
@@ -217,7 +215,7 @@ public class SampleEditFragment extends BaseEditFragment<FragmentSampleEditLayou
 				if (material == null || material == currentMaterial) {
 					return true;
 				}
-				return !material.isDeprecated() && (luxembourg || material != SampleMaterial.UNKNOWN);
+				return !material.isDeprecated();
 			})
 			.sorted(Comparator.comparing(Item::getKey, String.CASE_INSENSITIVE_ORDER))
 			.collect(Collectors.toList());

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/AbstractSampleForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/AbstractSampleForm.java
@@ -27,7 +27,6 @@ import com.vaadin.v7.ui.OptionGroup;
 import com.vaadin.v7.ui.TextArea;
 import com.vaadin.v7.ui.TextField;
 
-import de.symeda.sormas.api.CountryHelper;
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.FacadeProvider;
 import de.symeda.sormas.api.caze.CaseDataDto;
@@ -51,7 +50,6 @@ import de.symeda.sormas.api.sample.SpecimenCondition;
 import de.symeda.sormas.api.user.UserReferenceDto;
 import de.symeda.sormas.api.user.UserRight;
 import de.symeda.sormas.api.utils.Diseases;
-import de.symeda.sormas.api.utils.HideForCountries;
 import de.symeda.sormas.api.utils.fieldaccess.UiFieldAccessCheckers;
 import de.symeda.sormas.api.utils.fieldvisibility.FieldVisibilityCheckers;
 import de.symeda.sormas.api.utils.fieldvisibility.checkers.CountryFieldVisibilityChecker;
@@ -326,26 +324,15 @@ public abstract class AbstractSampleForm extends AbstractEditForm<SampleDto> {
 		}));
 	}
 
-	/**
-	 * Populates the sample-material dropdown with the specimens that are valid for new samples in the
-	 * current context: not deprecated, allowed for the configured country (via {@link HideForCountries},
-	 * e.g. the Luxembourg subset) and relevant to the sample's disease (via {@link Diseases}). The
-	 * currently saved material is always offered so an existing sample can still be edited even if its
-	 * specimen would no longer be shown for a new sample. Sorted alphabetically (English).
-	 */
 	private void updateSampleMaterialItems(ComboBox sampleMaterial, SampleMaterial selectedMaterial) {
 
-		final boolean luxembourg = FacadeProvider.getConfigFacade().isConfiguredCountry(CountryHelper.COUNTRY_CODE_LUXEMBOURG);
 		final CountryFieldVisibilityChecker countryChecker = new CountryFieldVisibilityChecker(FacadeProvider.getConfigFacade().getCountryLocale());
 		final List<SampleMaterial> diseaseVisible = Diseases.DiseasesConfiguration.getVisibleValues(SampleMaterial.class, disease);
 
 		List<SampleMaterial> items = Arrays.stream(SampleMaterial.values())
 			.filter(
 				material -> material == selectedMaterial
-					|| (!material.isDeprecated()
-						&& isVisibleForCountry(material, countryChecker)
-						&& diseaseVisible.contains(material)
-						&& (luxembourg || material != SampleMaterial.UNKNOWN)))
+					|| (!material.isDeprecated() && isVisibleForCountry(material, countryChecker) && diseaseVisible.contains(material)))
 			.sorted(Comparator.comparing(SampleMaterial::toString, String.CASE_INSENSITIVE_ORDER))
 			.collect(Collectors.toList());
 


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #14210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated sample material selection so available options are filtered consistently by deprecation, country visibility, and disease visibility.
  * Removed country-specific handling that could incorrectly affect the availability of the “Unknown” sample material.
  * Ensured the currently selected sample material remains available in the selection list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->