### PR TITLE
#14033 - Fixed enabling of ONGOING when result is PENDING

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/DiagnosisCriteriaLabTestPanel.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/DiagnosisCriteriaLabTestPanel.java
@@ -18,7 +18,6 @@ package de.symeda.sormas.ui.caze;
 import static de.symeda.sormas.ui.utils.LayoutUtil.fluidRowLocs;
 import static de.symeda.sormas.ui.utils.LayoutUtil.loc;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,11 +76,18 @@ public class DiagnosisCriteriaLabTestPanel extends CustomLayout {
 	private static final String TEST_RESULT_KEY_RESULT = "RESULT";
 	private static final String TEST_RESULT_KEY_DATE = "DATE";
 
+	private static final Map<String, String> PATHOGEN_TEST_RESULT_TO_CONTROLS_VALUES = Map.of(
+		PathogenTestResultType.POSITIVE.name(),
+		TEST_RESULT_POS,
+		PathogenTestResultType.NEGATIVE.name(),
+		TEST_RESULT_NEG,
+		PathogenTestResultType.PENDING.name(),
+		TEST_RESULT_ONGOING);
+
 	private Disease disease;
 	private List<PathogenTestDto> pathogenTests;
 
 	private Map<String, Map<String, String>> testDetails = new HashMap<>();
-	private List<String> positiveNegativeResult = Arrays.asList(PathogenTestResultType.POSITIVE.name(), PathogenTestResultType.NEGATIVE.name());
 
 	//@formatter:off
     private static final String HTML_LAYOUT =
@@ -113,18 +119,14 @@ public class DiagnosisCriteriaLabTestPanel extends CustomLayout {
 	private void initTestResultDetails() {
 		for (PathogenTestDto pathogenTest : pathogenTests) {
 			if (!testDetails.containsKey(pathogenTest.getTestType().name())) {
-				String testResult = null;
 				String testDate = null;
-				if (positiveNegativeResult.contains(pathogenTest.getTestResult().name())) {
-					testResult = pathogenTest.getTestResult().name();
-				}
 
 				if (pathogenTest.getTestDateTime() != null) {
 					testDate = DateFormatHelper.formatDate(pathogenTest.getTestDateTime());
 				}
 
 				Map<String, String> testResultDetails = new HashMap<>();
-				testResultDetails.put(TEST_RESULT_KEY_RESULT, testResult);
+				testResultDetails.put(TEST_RESULT_KEY_RESULT, pathogenTest.getTestResult().name());
 				testResultDetails.put(TEST_RESULT_KEY_DATE, testDate);
 				testResultDetails.put(
 					PathogenTestDto.RIFAMPICIN_RESISTANT,
@@ -148,7 +150,9 @@ public class DiagnosisCriteriaLabTestPanel extends CustomLayout {
 			TextField igraTestResultDate = addTextFieldComponent(IGRA_TEST_RESULT_DATE_LOC, "", true);
 			if (testDetails.containsKey(PathogenTestType.IGRA.name())) {
 				igraTest.setValue(TEST_TYPE_YES);
-				igraTestResult.setValue(testDetails.get(PathogenTestType.IGRA.name()).get(TEST_RESULT_KEY_RESULT));
+				final String resultValue =
+					PATHOGEN_TEST_RESULT_TO_CONTROLS_VALUES.get(testDetails.get(PathogenTestType.IGRA.name()).get(TEST_RESULT_KEY_RESULT));
+				igraTestResult.setValue(resultValue);
 				igraTestResultDate.setValue(testDetails.get(PathogenTestType.IGRA.name()).get(TEST_RESULT_KEY_DATE));
 			} else {
 				igraTest.setValue(TEST_TYPE_NO);
@@ -160,6 +164,9 @@ public class DiagnosisCriteriaLabTestPanel extends CustomLayout {
 			if (testDetails.containsKey(PathogenTestType.TST.name())) {
 				tstTest.setValue(TEST_TYPE_YES);
 				tstTestResult.setValue(testDetails.get(PathogenTestType.TST.name()).get(TEST_RESULT_KEY_RESULT));
+				final String resultValue =
+					PATHOGEN_TEST_RESULT_TO_CONTROLS_VALUES.get(testDetails.get(PathogenTestType.TST.name()).get(TEST_RESULT_KEY_RESULT));
+				tstTestResult.setValue(resultValue);
 				tstTestResultDate.setValue(testDetails.get(PathogenTestType.TST.name()).get(TEST_RESULT_KEY_DATE));
 			} else {
 				tstTest.setValue(TEST_TYPE_NO);
@@ -176,7 +183,9 @@ public class DiagnosisCriteriaLabTestPanel extends CustomLayout {
 				I18nProperties.getPrefixCaption(PathogenTestDto.I18N_PREFIX, PathogenTestDto.ISONIAZID_RESISTANT));
 			if (testDetails.containsKey(PathogenTestType.PCR_RT_PCR.name())) {
 				pcrTest.setValue(TEST_TYPE_YES);
-				pcrTestResult.setValue(testDetails.get(PathogenTestType.PCR_RT_PCR.name()).get(TEST_RESULT_KEY_RESULT));
+				final String resultValue =
+					PATHOGEN_TEST_RESULT_TO_CONTROLS_VALUES.get(testDetails.get(PathogenTestType.PCR_RT_PCR.name()).get(TEST_RESULT_KEY_RESULT));
+				pcrTestResult.setValue(resultValue);
 				pcrTestResultDate.setValue(testDetails.get(PathogenTestType.PCR_RT_PCR.name()).get(TEST_RESULT_KEY_DATE));
 
 				String pcrRifampicinStr = testDetails.get(PathogenTestType.PCR_RT_PCR.name()).get(PathogenTestDto.RIFAMPICIN_RESISTANT);
@@ -202,15 +211,21 @@ public class DiagnosisCriteriaLabTestPanel extends CustomLayout {
 			TextField microscopyTestScale = addTextFieldComponent(MICROSCOPY_TEST_SCALE_LOC, "", false);
 			if (testDetails.containsKey(PathogenTestType.MICROSCOPY.name())) {
 				microscopyTest.setValue(TEST_TYPE_YES);
-				microscopyTestResult.setValue(testDetails.get(PathogenTestType.MICROSCOPY.name()).get(TEST_RESULT_KEY_RESULT));
+				final String resultValue =
+					PATHOGEN_TEST_RESULT_TO_CONTROLS_VALUES.get(testDetails.get(PathogenTestType.MICROSCOPY.name()).get(TEST_RESULT_KEY_RESULT));
+				microscopyTestResult.setValue(resultValue);
 				microscopyTestResultDate.setValue(testDetails.get(PathogenTestType.MICROSCOPY.name()).get(TEST_RESULT_KEY_DATE));
-				microscopyTestScale.setValue(testDetails.get(PathogenTestType.MICROSCOPY.name()).get(PathogenTestDto.TEST_SCALE));
+				final String testScale = testDetails.get(PathogenTestType.MICROSCOPY.name()).get(PathogenTestDto.TEST_SCALE);
+				microscopyTestScale.setValue(testScale != null ? testScale : "");
 				microscopyTestScale.setCaption(I18nProperties.getCaption(Captions.PathogenTest_testScale));
 			} else if (testDetails.containsKey(PathogenTestType.ACID_FAST_STAIN.name())) {
 				microscopyTest.setValue(TEST_TYPE_YES);
-				microscopyTestResult.setValue(testDetails.get(PathogenTestType.ACID_FAST_STAIN.name()).get(TEST_RESULT_KEY_RESULT));
+				final String resultValue =
+					PATHOGEN_TEST_RESULT_TO_CONTROLS_VALUES.get(testDetails.get(PathogenTestType.ACID_FAST_STAIN.name()).get(TEST_RESULT_KEY_RESULT));
+				microscopyTestResult.setValue(resultValue);
 				microscopyTestResultDate.setValue(testDetails.get(PathogenTestType.ACID_FAST_STAIN.name()).get(TEST_RESULT_KEY_DATE));
-				microscopyTestScale.setValue(testDetails.get(PathogenTestType.ACID_FAST_STAIN.name()).get(PathogenTestDto.SMEAR_GRADE));
+				final String smearGrade = testDetails.get(PathogenTestType.ACID_FAST_STAIN.name()).get(PathogenTestDto.SMEAR_GRADE);
+				microscopyTestScale.setValue(smearGrade != null ? smearGrade : "");
 				microscopyTestScale.setCaption(I18nProperties.getCaption(Captions.PathogenTest_smearGrade));
 			} else {
 				microscopyTest.setValue(TEST_TYPE_NO);
@@ -222,7 +237,9 @@ public class DiagnosisCriteriaLabTestPanel extends CustomLayout {
 			TextField cultureTestResultDate = addTextFieldComponent(CULTURE_TEST_RESULT_DATE_LOC, "", true);
 			if (testDetails.containsKey(PathogenTestType.CULTURE.name())) {
 				cultureTest.setValue(TEST_TYPE_YES);
-				cultureTestResult.setValue(testDetails.get(PathogenTestType.CULTURE.name()).get(TEST_RESULT_KEY_RESULT));
+				final String resultValue =
+					PATHOGEN_TEST_RESULT_TO_CONTROLS_VALUES.get(testDetails.get(PathogenTestType.CULTURE.name()).get(TEST_RESULT_KEY_RESULT));
+				cultureTestResult.setValue(resultValue);
 				cultureTestResultDate.setValue(testDetails.get(PathogenTestType.CULTURE.name()).get(TEST_RESULT_KEY_DATE));
 			} else {
 				cultureTest.setValue(TEST_TYPE_NO);

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/DiagnosisCriteriaLabTestPanel.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/DiagnosisCriteriaLabTestPanel.java
@@ -76,13 +76,7 @@ public class DiagnosisCriteriaLabTestPanel extends CustomLayout {
 	private static final String TEST_RESULT_KEY_RESULT = "RESULT";
 	private static final String TEST_RESULT_KEY_DATE = "DATE";
 
-	private static final Map<String, String> PATHOGEN_TEST_RESULT_TO_CONTROLS_VALUES = Map.of(
-		PathogenTestResultType.POSITIVE.name(),
-		TEST_RESULT_POS,
-		PathogenTestResultType.NEGATIVE.name(),
-		TEST_RESULT_NEG,
-		PathogenTestResultType.PENDING.name(),
-		TEST_RESULT_ONGOING);
+	private static final Map<String, String> PATHOGEN_TEST_RESULT_TO_CONTROLS_VALUES;
 
 	private Disease disease;
 	private List<PathogenTestDto> pathogenTests;
@@ -103,6 +97,14 @@ public class DiagnosisCriteriaLabTestPanel extends CustomLayout {
                 + fluidRowLocs(6, BIOPSY_TEST_LOC, 4, BIOPSY_TEST_RESULT_LOC, 2, BIOPSY_TEST_RESULT_DATE_LOC)
                 + fluidRowLocs(6, CULTURE_TEST_LOC, 4, CULTURE_TEST_RESULT_LOC, 2, CULTURE_TEST_RESULT_DATE_LOC);
     //@formatter:on
+
+	static {
+		Map<String, String> map = new HashMap<>();
+		map.put(PathogenTestResultType.POSITIVE.name(), TEST_RESULT_POS);
+		map.put(PathogenTestResultType.NEGATIVE.name(), TEST_RESULT_NEG);
+		map.put(PathogenTestResultType.PENDING.name(), TEST_RESULT_ONGOING);
+		PATHOGEN_TEST_RESULT_TO_CONTROLS_VALUES = map;
+	}
 
 	public DiagnosisCriteriaLabTestPanel(Disease disease, List<PathogenTestDto> pathogenTests) {
 		setWidth(100, Sizeable.Unit.PERCENTAGE);
@@ -126,7 +128,7 @@ public class DiagnosisCriteriaLabTestPanel extends CustomLayout {
 				}
 
 				Map<String, String> testResultDetails = new HashMap<>();
-				testResultDetails.put(TEST_RESULT_KEY_RESULT, pathogenTest.getTestResult().name());
+				testResultDetails.put(TEST_RESULT_KEY_RESULT, pathogenTest.getTestResult() != null ? pathogenTest.getTestResult().name() : "");
 				testResultDetails.put(TEST_RESULT_KEY_DATE, testDate);
 				testResultDetails.put(
 					PathogenTestDto.RIFAMPICIN_RESISTANT,
@@ -163,7 +165,6 @@ public class DiagnosisCriteriaLabTestPanel extends CustomLayout {
 			TextField tstTestResultDate = addTextFieldComponent(TST_TEST_RESULT_DATE_LOC, "", true);
 			if (testDetails.containsKey(PathogenTestType.TST.name())) {
 				tstTest.setValue(TEST_TYPE_YES);
-				tstTestResult.setValue(testDetails.get(PathogenTestType.TST.name()).get(TEST_RESULT_KEY_RESULT));
 				final String resultValue =
 					PATHOGEN_TEST_RESULT_TO_CONTROLS_VALUES.get(testDetails.get(PathogenTestType.TST.name()).get(TEST_RESULT_KEY_RESULT));
 				tstTestResult.setValue(resultValue);


### PR DESCRIPTION
Fixes #14033 

- ONGOING should be toggled on when test result is PENDING

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display of laboratory test results across diagnosis criteria.
  * Correctly maps pathogen test result types (including ongoing) to the correct UI option selections.
  * Preserves and renders test-result details and dates more reliably.
  * Prevents null values from showing for microscopy/acid-fast stain scale and smear-grade fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->