### PR TITLE
#14219 - Show Serogrouping under its own name in the IPI test type list

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/i18n/Captions.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/i18n/Captions.java
@@ -2432,7 +2432,6 @@ public interface Captions {
 	String PathogenTest_rsv_testedDiseaseVariant = "PathogenTest.rsv.testedDiseaseVariant";
 	String PathogenTest_rsv_testedDiseaseVariantDetails = "PathogenTest.rsv.testedDiseaseVariantDetails";
 	String PathogenTest_rsvSubtype = "PathogenTest.rsvSubtype";
-	String PathogenTest_seroGrouping_INVASIVE_PNEUMOCOCCAL_INFECTION = "PathogenTest.seroGrouping.INVASIVE_PNEUMOCOCCAL_INFECTION";
 	String PathogenTest_seroGroupSpecification = "PathogenTest.seroGroupSpecification";
 	String PathogenTest_seroGroupSpecificationText = "PathogenTest.seroGroupSpecificationText";
 	String PathogenTest_serotype = "PathogenTest.serotype";

--- a/sormas-api/src/main/resources/captions.properties
+++ b/sormas-api/src/main/resources/captions.properties
@@ -1993,7 +1993,6 @@ PathogenTest.seroTypingMethod=Sero Typing Method
 PathogenTest.seroTypingMethodText=Specify Sero Typing Method
 PathogenTest.seroTypingMethod.INVASIVE_PNEUMOCOCCAL_INFECTION=Serotyping Method
 PathogenTest.serotypeText.INVASIVE_PNEUMOCOCCAL_INFECTION=Serotype
-PathogenTest.seroGrouping.INVASIVE_PNEUMOCOCCAL_INFECTION=Serotyping
 PathogenTest.seroGroupSpecification=Serogroup Specification
 PathogenTest.seroGroupSpecificationText=Specify Serogroup Specification Method
 PathogenTest.genoType=Genotype result

--- a/sormas-api/src/test/java/de/symeda/sormas/api/sample/PathogenTestTypeTest.java
+++ b/sormas-api/src/test/java/de/symeda/sormas/api/sample/PathogenTestTypeTest.java
@@ -295,6 +295,19 @@ public class PathogenTestTypeTest {
 	}
 
 	@Test
+	public void serogroupingIsSelectableForInvasivePneumococcalInfectionUnderItsOwnName() {
+		List<PathogenTestType> visibleForIpi = de.symeda.sormas.api.utils.Diseases.DiseasesConfiguration
+			.getVisibleValues(PathogenTestType.class, Disease.INVASIVE_PNEUMOCOCCAL_INFECTION);
+
+		assertThat(visibleForIpi, hasItem(PathogenTestType.SEROGROUPING));
+		assertTrue(PathogenTestType.isSelectableForNewTests(PathogenTestType.SEROGROUPING));
+		assertThat(PathogenTestType.getCategory(PathogenTestType.SEROGROUPING), is(PathogenTestCategory.MOLECULAR_ASSAYS));
+		assertThat(PathogenTestType.SEROGROUPING.toString(), is("Serogrouping"));
+
+		assertThat(visibleForIpi, not(hasItem(PathogenTestType.SEROTYPING)));
+	}
+
+	@Test
 	public void diseaseHiddenMethodIsDroppedByVisibleValues() {
 		// Guards the scenario behind the retainType re-add in FormComponent#updateTestTypeItemsByCategory
 		// and the retainCategory re-add in #getVisibleTestCategories: a method that is @Diseases(hide = true)

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/components/TestMethodComponent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/components/TestMethodComponent.java
@@ -112,7 +112,7 @@ public class TestMethodComponent extends FormComponent<PathogenTestDto> {
 		// Test type
 		testTypeField = createComboBox(PathogenTestDto.TEST_TYPE, PathogenTestDto.I18N_PREFIX);
 		updateTestTypeItemsByCategory(testTypeField, currentDisease, null);
-		testTypeField.setItemCaptionGenerator(this::getTestTypeCaption);
+		testTypeField.setItemCaptionGenerator(PathogenTestType::toString);
 
 		testTypeTextField = createTextField(PathogenTestDto.TEST_TYPE_TEXT, PathogenTestDto.I18N_PREFIX, ValueChangeMode.BLUR);
 		testTypeTextField.setVisible(false);
@@ -315,17 +315,6 @@ public class TestMethodComponent extends FormComponent<PathogenTestDto> {
 		testCategoryField.clear();
 		testTypeField.clear();
 		updateTestTypeItemsByCategory(testTypeField, disease, null);
-	}
-
-	/**
-	 * Disease-aware caption for a test type. For Invasive Pneumococcal Infection the SEROGROUPING
-	 * test type is presented as "Serotyping" without affecting other diseases.
-	 */
-	private String getTestTypeCaption(PathogenTestType testType) {
-		if (currentDisease == Disease.INVASIVE_PNEUMOCOCCAL_INFECTION && testType == PathogenTestType.SEROGROUPING) {
-			return I18nProperties.getCaption(Captions.PathogenTest_seroGrouping_INVASIVE_PNEUMOCOCCAL_INFECTION);
-		}
-		return PathogenTestType.toString(testType, null);
 	}
 
 	private void updatePcrTestSpecVisibility(PathogenTestType testType) {


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #14219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the displayed pathogen test method for invasive pneumococcal infection.
  * Serogrouping is now shown under its correct name instead of being labeled “Serotyping.”
  * Updated available test method options so serogrouping is selectable and serotyping is excluded for this condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->