### PR TITLE
Add SessionStart hook to configure Maven for the web environment

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# SessionStart hook for Claude Code on the web.
+#
+# Configures Maven so that `mvn clean install` resolves all dependencies through
+# the managed egress proxy of the remote environment. Two issues are handled:
+#
+#   1. The maven-resolver HTTP transport (Apache HttpClient) does NOT read the
+#      JVM proxy system properties (https.proxyHost/Port from JAVA_TOOL_OPTIONS)
+#      by default, so it bypasses the egress proxy and gets HTTP 403. We enable
+#      `aether.connector.http.useSystemProperties` via MAVEN_OPTS so it honors
+#      the proxy that is already configured for this session.
+#
+#   2. The egress policy allowlists repo1.maven.org but NOT the canonical Central
+#      host repo.maven.apache.org (used by Maven's built-in super-POM), which is
+#      blocked with 403. Both serve identical Maven Central content, so we mirror
+#      every "central" request to repo1.maven.org via ~/.m2/settings.xml.
+#
+# The hook is idempotent and only does anything in the remote (web) environment;
+# on a local machine with direct internet access it exits immediately.
+
+set -euo pipefail
+
+# Only relevant for Claude Code on the web (managed egress proxy). Skip locally.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# 1) Mirror Maven Central (repo.maven.apache.org) to the allowlisted repo1 host.
+mkdir -p "$HOME/.m2"
+cat > "$HOME/.m2/settings.xml" << 'SETTINGS'
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                              https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <!--
+    Egress environment: only repo1.maven.org is allowlisted, the canonical
+    Central host repo.maven.apache.org is policy-blocked (403). Both are
+    identical Maven Central, so route all "central" requests (repository AND
+    plugin repository from the super-POM) to repo1.maven.org.
+  -->
+  <mirrors>
+    <mirror>
+      <id>central-repo1</id>
+      <name>Maven Central via repo1 (allowlisted host)</name>
+      <mirrorOf>central</mirrorOf>
+      <url>https://repo1.maven.org/maven2</url>
+    </mirror>
+  </mirrors>
+</settings>
+SETTINGS
+
+# 2) Make the maven-resolver HTTP transport use the JVM proxy system properties
+#    so it routes through the egress proxy instead of connecting directly.
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  echo 'export MAVEN_OPTS="${MAVEN_OPTS:-} -Daether.connector.http.useSystemProperties=true"' >> "$CLAUDE_ENV_FILE"
+fi
+
+echo "SORMAS Maven proxy/mirror configured for the web environment (~/.m2/settings.xml)."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
SORMAS did not build in Claude Code on the web because Maven could not resolve dependencies through the managed egress proxy:

- maven-resolver (Apache HttpClient) ignores the JVM proxy system properties by default and connected directly, hitting HTTP 403.
- The canonical Central host repo.maven.apache.org is not allowlisted by the egress policy (only repo1.maven.org is), also returning 403.

The hook writes ~/.m2/settings.xml mirroring "central" to the allowlisted repo1.maven.org and enables aether.connector.http.useSystemProperties via MAVEN_OPTS so the resolver uses the egress proxy. Runs only in the remote web environment and is idempotent.


Claude-Session: https://claude.ai/code/session_0118Dbk7fXMUfPoviNqkdN69

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic setup for remote development sessions to improve Maven dependency resolution.
  * Configured Maven to use the approved repository mirror and proxy-aware connection settings when applicable.
  * Registered the setup to run automatically at session start.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->