### PR TITLE
Invalid Laboratory mapping in pathogen test result

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/processing/ExternalMessageMapper.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/externalmessage/processing/ExternalMessageMapper.java
@@ -692,7 +692,7 @@ public final class ExternalMessageMapper {
 						Mapping.of(
 							pathogenTest::setLab,
 							pathogenTest.getLab(),
-							processingFacade.getFacilityReference(sourceTestReport.getTestLabExternalIds()),
+							processingFacade.getFacilityReference(externalMessage.getReporterExternalIds()),
 							PathogenTestDto.LAB),
 						Mapping.of(
 							pathogenTest::setLabDetails,

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/TestDataCreator.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/TestDataCreator.java
@@ -2009,6 +2009,25 @@ public class TestDataCreator {
 	}
 
 	public FacilityDto createFacility(
+			String facilityName,
+			String externalId,
+			RegionReferenceDto region,
+			DistrictReferenceDto district,
+			CommunityReferenceDto community,
+			FacilityType type) {
+
+		FacilityDto facility = FacilityDto.build();
+		facility.setName(facilityName);
+		facility.setExternalID(externalId);
+		facility.setType(type == null ? FacilityType.HOSPITAL : type);
+		facility.setCommunity(community);
+		facility.setDistrict(district);
+		facility.setRegion(region);
+		beanTest.getFacilityFacade().save(facility);
+		return facility;
+	}
+
+	public FacilityDto createFacility(
 		String facilityName,
 		RegionReferenceDto region,
 		DistrictReferenceDto district,

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/externalmessage/processing/ExternalMessageMapperTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/externalmessage/processing/ExternalMessageMapperTest.java
@@ -34,6 +34,9 @@ import de.symeda.sormas.api.externalmessage.processing.ExternalMessageMapper;
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.person.PersonDto;
 import de.symeda.sormas.api.person.PresentCondition;
+import de.symeda.sormas.api.infrastructure.facility.FacilityDto;
+import de.symeda.sormas.api.infrastructure.facility.FacilityReferenceDto;
+import de.symeda.sormas.api.infrastructure.facility.FacilityType;
 import de.symeda.sormas.api.sample.PathogenTestDto;
 import de.symeda.sormas.api.sample.PathogenTestResultType;
 import de.symeda.sormas.api.sample.SampleDto;
@@ -205,5 +208,34 @@ public class ExternalMessageMapperTest extends AbstractBeanTest {
 		assertEquals(expectedResult.get(0)[0], result.get(0)[0]);
 		assertEquals(PresentCondition.ALIVE, person.getPresentCondition());
 
+	}
+
+	@Test
+	public void testMapToPathogenTestSetsLab() {
+		// Create a lab facility with external ID
+		var rdcf = creator.createRDCF();
+		FacilityDto labFacility = creator.createFacility("TestLab", rdcf.region, rdcf.district, rdcf.community, FacilityType.LABORATORY);
+		String labExternalId = "testLabExternalId";
+		labFacility.setExternalID(labExternalId);
+		getFacilityFacade().save(labFacility);
+
+		// Create external message with reporterExternalIds pointing to the lab
+		ExternalMessageDto externalMessage = ExternalMessageDto.build();
+		externalMessage.setReporterExternalIds(List.of(labExternalId));
+
+		// Create test report and pathogen test
+		TestReportDto testReport = TestReportDto.build();
+		PathogenTestDto pathogenTest = new PathogenTestDto();
+
+		// Initially lab should be null
+		assertNull(pathogenTest.getLab());
+
+		// Create mapper and map to pathogen test
+		ExternalMessageMapper mapper = new ExternalMessageMapper(externalMessage, getExternalMessageProcessingFacade());
+		mapper.mapToPathogenTest(testReport, pathogenTest);
+
+		// Verify lab is properly set
+		FacilityReferenceDto expectedLabReference = labFacility.toReference();
+		assertEquals(expectedLabReference, pathogenTest.getLab());
 	}
 }

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/externalmessage/processing/ExternalMessageMapperTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/externalmessage/processing/ExternalMessageMapperTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.List;
 
+import de.symeda.sormas.api.therapy.DrugSusceptibilityDto;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.junit.jupiter.api.Test;
 
@@ -214,10 +215,8 @@ public class ExternalMessageMapperTest extends AbstractBeanTest {
 	public void testMapToPathogenTestSetsLab() {
 		// Create a lab facility with external ID
 		var rdcf = creator.createRDCF();
-		FacilityDto labFacility = creator.createFacility("TestLab", rdcf.region, rdcf.district, rdcf.community, FacilityType.LABORATORY);
 		String labExternalId = "testLabExternalId";
-		labFacility.setExternalID(labExternalId);
-		getFacilityFacade().save(labFacility);
+		FacilityDto labFacility = creator.createFacility("TestLab", labExternalId, rdcf.region, rdcf.district, rdcf.community, FacilityType.LABORATORY);
 
 		// Create external message with reporterExternalIds pointing to the lab
 		ExternalMessageDto externalMessage = ExternalMessageDto.build();
@@ -226,9 +225,7 @@ public class ExternalMessageMapperTest extends AbstractBeanTest {
 		// Create test report and pathogen test
 		TestReportDto testReport = TestReportDto.build();
 		PathogenTestDto pathogenTest = new PathogenTestDto();
-
-		// Initially lab should be null
-		assertNull(pathogenTest.getLab());
+		pathogenTest.setDrugSusceptibility(new DrugSusceptibilityDto());
 
 		// Create mapper and map to pathogen test
 		ExternalMessageMapper mapper = new ExternalMessageMapper(externalMessage, getExternalMessageProcessingFacade());

--- a/sormas-ui/src/test/java/de/symeda/sormas/ui/externalmessage/labmessage/RelatedLabMessageHandlerTest.java
+++ b/sormas-ui/src/test/java/de/symeda/sormas/ui/externalmessage/labmessage/RelatedLabMessageHandlerTest.java
@@ -505,8 +505,9 @@ public class RelatedLabMessageHandlerTest extends AbstractUiBeanTest {
 			assertThat(originalTest.getUuid(), is(updatedTest.getUuid()));
 
 			List<String[]> changedFields = invocation.getArgument(3);
-			assertThat(changedFields, hasSize(1));
+			assertThat(changedFields, hasSize(2));
 			assertThat(changedFields.get(0), arrayContaining(PathogenTestDto.TEST_TYPE));
+			assertThat(changedFields.get(1), arrayContaining(PathogenTestDto.LAB));
 
 			((RelatedLabMessageHandlerChain) invocation.getArgument(4)).next(true);
 
@@ -586,8 +587,9 @@ public class RelatedLabMessageHandlerTest extends AbstractUiBeanTest {
 
 				assertThat(updatedTest.getTestType(), is(testReport1.getTestType()));
 
-				assertThat(changedFields, hasSize(1));
+				assertThat(changedFields, hasSize(2));
 				assertThat(changedFields.get(0), arrayContaining(PathogenTestDto.TEST_TYPE));
+				assertThat(changedFields.get(1), arrayContaining(PathogenTestDto.LAB));
 			} else if (originalTest.getUuid().equals(pathogenTest2.getUuid())) {
 				assertThat(originalTest.getExternalId(), is("test-external-id-2"));
 				assertThat(originalTest.getTestType(), is(pathogenTest2.getTestType()));
@@ -595,8 +597,9 @@ public class RelatedLabMessageHandlerTest extends AbstractUiBeanTest {
 				assertThat(updatedTest.getTestType(), is(testReport2.getTestType()));
 				assertThat(updatedTest.getTestResult(), is(testReport2.getTestResult()));
 
-				assertThat(changedFields, hasSize(1));
+				assertThat(changedFields, hasSize(2));
 				assertThat(changedFields.get(0), arrayContaining(PathogenTestDto.TEST_RESULT));
+				assertThat(changedFields.get(1), arrayContaining(PathogenTestDto.LAB));
 			}
 
 			((RelatedLabMessageHandlerChain) invocation.getArgument(4)).next(true);
@@ -634,7 +637,6 @@ public class RelatedLabMessageHandlerTest extends AbstractUiBeanTest {
 		labMessageToProcess.setPersonLastName(person.getLastName());
 		labMessageToProcess.setPersonSex(person.getSex());
 		labMessageToProcess.getSampleReports().get(0).setSampleMaterial(sample.getSampleMaterial());
-		labMessageToProcess.setReporterExternalIds(Collections.singletonList(sample.getLab().getExternalId()));
 		labMessageToProcess.getSampleReports().get(0).setSampleDateTime(sample.getSampleDateTime());
 		labMessageToProcess.getSampleReports().get(0).setSpecimenCondition(sample.getSpecimenCondition());
 


### PR DESCRIPTION
This mapping was already working for Samples, but they must have the same value as there is only this information present in the XML lab result
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #14258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pathogen test processing so the correct laboratory is assigned based on the external message reporter.
  * Ensured laboratory changes are reflected when correcting pathogen test types or results.
  * Added validation coverage to ensure laboratory details are mapped correctly in these scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->