### PR TITLE
FIX: 14280 :  LUX - NationalHealthId handling

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/utils/luxembourg/LuxembourgNationalHealthIdValidator.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/utils/luxembourg/LuxembourgNationalHealthIdValidator.java
@@ -15,53 +15,77 @@
 
 package de.symeda.sormas.api.utils.luxembourg;
 
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class LuxembourgNationalHealthIdValidator {
 
-	/**
-	 * - AAAA = année de naissance
-	 * - MM = mois de naissance
-	 * - JJ = jour de naissance
-	 * - XXX = numéro aléatoire unique par date de naissance
-	 * - C1 = numéro de contrôle calculé sur AAAAMMJJXXX suivant l’algorithme LUHN 10
-	 * - C2 = numéro de contrôle calculé sur AAAAMMJJXXX suivant l’algorithme VERHOEFF
-	 */
-	private static final Pattern NATIONAL_HEALTH_ID_PATTERN = Pattern.compile("(\\d{4})(\\d{2})(\\d{2})(\\d{3})(\\d)(\\d)");
+    /**
+     * - AAAA = année de naissance
+     * - MM = mois de naissance
+     * - JJ = jour de naissance
+     * - XXX = numéro aléatoire unique par date de naissance
+     * - C1 = numéro de contrôle calculé sur AAAAMMJJXXX suivant l’algorithme LUHN 10
+     * - C2 = numéro de contrôle calculé sur AAAAMMJJXXX suivant l’algorithme VERHOEFF
+     */
+    private static final Pattern NATIONAL_HEALTH_ID_PATTERN = Pattern.compile("(\\d{4})(\\d{2})(\\d{2})(\\d{3})(\\d)(\\d)");
 
-	public static boolean isValid(String nationalHealthId, Integer birthdateYYYY, Integer birthdateMM, Integer birthdateDD) {
-		if (nationalHealthId == null) {
-			return false;
-		}
+    public static Optional<FailureCause> isValidWithCause(String nationalHealthId) {
+        return isValidWithCause(nationalHealthId, null, null, null);
+    }
 
-		Matcher patternMatcher = NATIONAL_HEALTH_ID_PATTERN.matcher(nationalHealthId);
-		if (!patternMatcher.matches()) {
-			return false;
-		}
+    public static Optional<FailureCause> isValidWithCause(String nationalHealthId, Integer birthdateYYYY, Integer birthdateMM, Integer birthdateDD) {
+        if (nationalHealthId == null) {
+            return Optional.of(FailureCause.EMPTY);
+        }
 
-		String yyyy = patternMatcher.group(1);
-		String mm = patternMatcher.group(2);
-		String dd = patternMatcher.group(3);
-		String xxx = patternMatcher.group(4);
-		String c1 = patternMatcher.group(5);
-		String c2 = patternMatcher.group(6);
+        Matcher patternMatcher = NATIONAL_HEALTH_ID_PATTERN.matcher(nationalHealthId);
+        if (!patternMatcher.matches()) {
+            return Optional.of(FailureCause.PATTERN);
+        }
 
-		if (isNullOrEquals(birthdateYYYY, Integer.parseInt(yyyy))
-			&& isNullOrEquals(birthdateMM, Integer.parseInt(mm))
-			&& isNullOrEquals(birthdateDD, Integer.parseInt(dd))) {
-			String iNumber = yyyy + mm + dd + xxx;
+        String yyyy = patternMatcher.group(1);
+        String mm = patternMatcher.group(2);
+        String dd = patternMatcher.group(3);
+        String xxx = patternMatcher.group(4);
+        String c1 = patternMatcher.group(5);
+        String c2 = patternMatcher.group(6);
 
-			if (CheckDigitLuhn.checkDigit(iNumber + c1) && CheckDigitVerhoeff.checkDigit(iNumber + c2)) {
-				return true;
-			}
-		}
+        int birthDateWithinNationalHealthId = Integer.parseInt(yyyy);
+        if (nationalHealthId.startsWith("3")) {
+            birthDateWithinNationalHealthId = birthDateWithinNationalHealthId + 2000;
+        }
 
-		return false;
-	}
+        if (!(birthdateYYYY == null && birthdateMM == null && birthdateDD == null)) {
+            if (!(isNullOrEquals(birthdateYYYY, birthDateWithinNationalHealthId)
+                    && isNullOrEquals(birthdateMM, Integer.parseInt(mm))
+                    && isNullOrEquals(birthdateDD, Integer.parseInt(dd)))) {
 
-	private static boolean isNullOrEquals(Integer personBirthdateFieldValue, int yyyy) {
-		return personBirthdateFieldValue == null || personBirthdateFieldValue == yyyy;
-	}
+                return Optional.of(FailureCause.BIRTHDATE);
+            }
+        }
 
+        String iNumber = yyyy + mm + dd + xxx;
+        if (!(CheckDigitLuhn.checkDigit(iNumber + c1) && CheckDigitVerhoeff.checkDigit(iNumber + c2))) {
+            return Optional.of(FailureCause.CHECK_DIGIT);
+        }
+
+        return Optional.empty();
+    }
+
+    public static boolean isValid(String nationalHealthId, Integer birthdateYYYY, Integer birthdateMM, Integer birthdateDD) {
+        return isValidWithCause(nationalHealthId, birthdateYYYY, birthdateMM, birthdateDD).isEmpty();
+    }
+
+    private static boolean isNullOrEquals(Integer personBirthdateFieldValue, int yyyy) {
+        return personBirthdateFieldValue == null || personBirthdateFieldValue == yyyy;
+    }
+
+    public enum FailureCause {
+        EMPTY,
+        CHECK_DIGIT,
+        PATTERN,
+        BIRTHDATE
+    }
 }

--- a/sormas-api/src/main/java/de/symeda/sormas/api/utils/luxembourg/LuxembourgNationalHealthIdValidator.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/utils/luxembourg/LuxembourgNationalHealthIdValidator.java
@@ -31,6 +31,11 @@ public class LuxembourgNationalHealthIdValidator {
      */
     private static final Pattern NATIONAL_HEALTH_ID_PATTERN = Pattern.compile("(\\d{4})(\\d{2})(\\d{2})(\\d{3})(\\d)(\\d)");
 
+    /**
+     * Non-standard LU - NationalHealths ids start with _3_990 -> 1990 or 4006 -> 2006
+     */
+    private static final int YEAR_ADDITION_FOR_NON_STANDARD_HEALTH_IDS = 2000;
+
     public static Optional<FailureCause> isValidWithCause(String nationalHealthId) {
         return isValidWithCause(nationalHealthId, null, null, null);
     }
@@ -53,8 +58,8 @@ public class LuxembourgNationalHealthIdValidator {
         String c2 = patternMatcher.group(6);
 
         int birthDateWithinNationalHealthId = Integer.parseInt(yyyy);
-        if (nationalHealthId.startsWith("3")) {
-            birthDateWithinNationalHealthId = birthDateWithinNationalHealthId + 2000;
+        if (nationalHealthId.startsWith("3") || nationalHealthId.startsWith("4")) {
+            birthDateWithinNationalHealthId = birthDateWithinNationalHealthId - YEAR_ADDITION_FOR_NON_STANDARD_HEALTH_IDS;
         }
 
         if (!(birthdateYYYY == null && birthdateMM == null && birthdateDD == null)) {

--- a/sormas-api/src/main/java/de/symeda/sormas/api/utils/luxembourg/LuxembourgNationalHealthIdValidator.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/utils/luxembourg/LuxembourgNationalHealthIdValidator.java
@@ -36,10 +36,6 @@ public class LuxembourgNationalHealthIdValidator {
      */
     private static final int YEAR_ADDITION_FOR_NON_STANDARD_HEALTH_IDS = 2000;
 
-    public static Optional<FailureCause> isValidWithCause(String nationalHealthId) {
-        return isValidWithCause(nationalHealthId, null, null, null);
-    }
-
     public static Optional<FailureCause> isValidWithCause(String nationalHealthId, Integer birthdateYYYY, Integer birthdateMM, Integer birthdateDD) {
         if (nationalHealthId == null) {
             return Optional.of(FailureCause.EMPTY);
@@ -73,10 +69,14 @@ public class LuxembourgNationalHealthIdValidator {
 
         String iNumber = yyyy + mm + dd + xxx;
         if (!(CheckDigitLuhn.checkDigit(iNumber + c1) && CheckDigitVerhoeff.checkDigit(iNumber + c2))) {
-            return Optional.of(FailureCause.CHECK_DIGIT);
+            return Optional.of(FailureCause.CHECK_DIGITS);
         }
 
         return Optional.empty();
+    }
+
+    public static Optional<FailureCause> isValidWithCause(String nationalHealthId) {
+        return isValidWithCause(nationalHealthId, null, null, null);
     }
 
     public static boolean isValid(String nationalHealthId, Integer birthdateYYYY, Integer birthdateMM, Integer birthdateDD) {
@@ -89,7 +89,7 @@ public class LuxembourgNationalHealthIdValidator {
 
     public enum FailureCause {
         EMPTY,
-        CHECK_DIGIT,
+        CHECK_DIGITS,
         PATTERN,
         BIRTHDATE
     }

--- a/sormas-api/src/main/java/de/symeda/sormas/api/utils/luxembourg/LuxembourgNationalHealthIdValidator.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/utils/luxembourg/LuxembourgNationalHealthIdValidator.java
@@ -58,13 +58,11 @@ public class LuxembourgNationalHealthIdValidator {
             birthDateWithinNationalHealthId = birthDateWithinNationalHealthId - YEAR_ADDITION_FOR_NON_STANDARD_HEALTH_IDS;
         }
 
-        if (!(birthdateYYYY == null && birthdateMM == null && birthdateDD == null)) {
-            if (!(isNullOrEquals(birthdateYYYY, birthDateWithinNationalHealthId)
-                    && isNullOrEquals(birthdateMM, Integer.parseInt(mm))
-                    && isNullOrEquals(birthdateDD, Integer.parseInt(dd)))) {
+        if (!(isNullOrEquals(birthdateYYYY, birthDateWithinNationalHealthId)
+                && isNullOrEquals(birthdateMM, Integer.parseInt(mm))
+                && isNullOrEquals(birthdateDD, Integer.parseInt(dd)))) {
 
-                return Optional.of(FailureCause.BIRTHDATE);
-            }
+            return Optional.of(FailureCause.BIRTHDATE);
         }
 
         String iNumber = yyyy + mm + dd + xxx;

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/util/luxembourg/LuxembourgNationalHealthIdValidatorTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/util/luxembourg/LuxembourgNationalHealthIdValidatorTest.java
@@ -21,9 +21,12 @@ package de.symeda.sormas.backend.util.luxembourg;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import de.symeda.sormas.api.utils.luxembourg.LuxembourgNationalHealthIdValidator;
+
+import java.util.Optional;
 
 public class LuxembourgNationalHealthIdValidatorTest {
 
@@ -51,5 +54,21 @@ public class LuxembourgNationalHealthIdValidatorTest {
 		assertThat(LuxembourgNationalHealthIdValidator.isValid("1980010145718", 1980, 1, 1), is(false));
 		assertThat(LuxembourgNationalHealthIdValidator.isValid("1980010145723", 1980, 1, 1), is(false));
 		assertThat(LuxembourgNationalHealthIdValidator.isValid("1980010345728", 1980, 1, null), is(false));
+	}
+
+	@Test
+	void test_non_standard_validation() {
+		Optional<LuxembourgNationalHealthIdValidator.FailureCause> validWithCause = LuxembourgNationalHealthIdValidator.isValidWithCause("3980010145721");
+
+		System.out.println("validWithCause = " + validWithCause);
+		Assertions.assertTrue(validWithCause.isEmpty());
+	}
+
+	@Test
+	void test_without_birthdate() {
+		Optional<LuxembourgNationalHealthIdValidator.FailureCause> validWithCause = LuxembourgNationalHealthIdValidator.isValidWithCause("3980010145721");
+
+		System.out.println("validWithCause = " + validWithCause);
+		Assertions.assertTrue(validWithCause.isEmpty());
 	}
 }

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/util/luxembourg/LuxembourgNationalHealthIdValidatorTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/util/luxembourg/LuxembourgNationalHealthIdValidatorTest.java
@@ -18,57 +18,102 @@
 
 package de.symeda.sormas.backend.util.luxembourg;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-
+import de.symeda.sormas.api.utils.luxembourg.LuxembourgNationalHealthIdValidator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import de.symeda.sormas.api.utils.luxembourg.LuxembourgNationalHealthIdValidator;
-
 import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class LuxembourgNationalHealthIdValidatorTest {
 
-	public static final String VALID_LU_NATIONAL_HEALTH_ID = "1980010145728";
+    public static final String VALID_LU_NATIONAL_HEALTH_ID = "1980010145728";
 
-	@Test
-	public void testIsValid() {
-		assertThat(LuxembourgNationalHealthIdValidator.isValid("19800101", 1980, 1, 1), is(false));
-		assertThat(LuxembourgNationalHealthIdValidator.isValid("1980Jan0145728", 1980, 1, 1), is(false));
-		assertThat(LuxembourgNationalHealthIdValidator.isValid("1980Ja0145728", 1980, 1, 1), is(false));
+    @Test
+    public void testIsValid() {
+        Assertions.assertAll(
+                () -> assertThat(LuxembourgNationalHealthIdValidator.isValid("19800101", 1980, 1, 1), is(false)),
+                () -> assertThat(LuxembourgNationalHealthIdValidator.isValid("1980Jan0145728", 1980, 1, 1), is(false)),
+                () -> assertThat(LuxembourgNationalHealthIdValidator.isValid("1980Ja0145728", 1980, 1, 1), is(false)),
 
-		assertThat(LuxembourgNationalHealthIdValidator.isValid(VALID_LU_NATIONAL_HEALTH_ID, 1980, 1, 1), is(true));
-		assertThat(LuxembourgNationalHealthIdValidator.isValid(VALID_LU_NATIONAL_HEALTH_ID, null, 1, 1), is(true));
-		assertThat(LuxembourgNationalHealthIdValidator.isValid(VALID_LU_NATIONAL_HEALTH_ID, 1980, 1, null), is(true));
-		assertThat(LuxembourgNationalHealthIdValidator.isValid(VALID_LU_NATIONAL_HEALTH_ID, 1980, null, 1), is(true));
-		assertThat(LuxembourgNationalHealthIdValidator.isValid(VALID_LU_NATIONAL_HEALTH_ID, 1980, null, null), is(true));
-		assertThat(LuxembourgNationalHealthIdValidator.isValid(VALID_LU_NATIONAL_HEALTH_ID, null, null, null), is(true));
+                () -> assertThat(LuxembourgNationalHealthIdValidator.isValid(VALID_LU_NATIONAL_HEALTH_ID, 1980, 1, 1), is(true)),
+                () -> assertThat(LuxembourgNationalHealthIdValidator.isValid(VALID_LU_NATIONAL_HEALTH_ID, null, 1, 1), is(true)),
+                () -> assertThat(LuxembourgNationalHealthIdValidator.isValid(VALID_LU_NATIONAL_HEALTH_ID, 1980, 1, null), is(true)),
+                () -> assertThat(LuxembourgNationalHealthIdValidator.isValid(VALID_LU_NATIONAL_HEALTH_ID, 1980, null, 1), is(true)),
+                () -> assertThat(LuxembourgNationalHealthIdValidator.isValid(VALID_LU_NATIONAL_HEALTH_ID, 1980, null, null), is(true)),
+                () -> assertThat(LuxembourgNationalHealthIdValidator.isValid(VALID_LU_NATIONAL_HEALTH_ID, null, null, null), is(true)),
 
-		assertThat(LuxembourgNationalHealthIdValidator.isValid(VALID_LU_NATIONAL_HEALTH_ID, 1981, 1, 1), is(false));
-		assertThat(LuxembourgNationalHealthIdValidator.isValid(VALID_LU_NATIONAL_HEALTH_ID, 1980, 2, 1), is(false));
-		assertThat(LuxembourgNationalHealthIdValidator.isValid(VALID_LU_NATIONAL_HEALTH_ID, 1980, 1, 2), is(false));
-		assertThat(LuxembourgNationalHealthIdValidator.isValid(VALID_LU_NATIONAL_HEALTH_ID, 1981, 1, null), is(false));
+                () -> assertThat(LuxembourgNationalHealthIdValidator.isValid(VALID_LU_NATIONAL_HEALTH_ID, 1981, 1, 1), is(false)),
+                () -> assertThat(LuxembourgNationalHealthIdValidator.isValid(VALID_LU_NATIONAL_HEALTH_ID, 1980, 2, 1), is(false)),
+                () -> assertThat(LuxembourgNationalHealthIdValidator.isValid(VALID_LU_NATIONAL_HEALTH_ID, 1980, 1, 2), is(false)),
+                () -> assertThat(LuxembourgNationalHealthIdValidator.isValid(VALID_LU_NATIONAL_HEALTH_ID, 1981, 1, null), is(false)),
 
-		assertThat(LuxembourgNationalHealthIdValidator.isValid("1980010145628", 1980, 1, 1), is(false));
-		assertThat(LuxembourgNationalHealthIdValidator.isValid("1980010145718", 1980, 1, 1), is(false));
-		assertThat(LuxembourgNationalHealthIdValidator.isValid("1980010145723", 1980, 1, 1), is(false));
-		assertThat(LuxembourgNationalHealthIdValidator.isValid("1980010345728", 1980, 1, null), is(false));
-	}
+                () -> assertThat(LuxembourgNationalHealthIdValidator.isValid("1980010145628", 1980, 1, 1), is(false)),
+                () -> assertThat(LuxembourgNationalHealthIdValidator.isValid("1980010145718", 1980, 1, 1), is(false)),
+                () -> assertThat(LuxembourgNationalHealthIdValidator.isValid("1980010145723", 1980, 1, 1), is(false)),
+                () -> assertThat(LuxembourgNationalHealthIdValidator.isValid("1980010345728", 1980, 1, null), is(false))
+        );
+    }
 
-	@Test
-	void test_non_standard_validation() {
-		Optional<LuxembourgNationalHealthIdValidator.FailureCause> validWithCause = LuxembourgNationalHealthIdValidator.isValidWithCause("3980010145721");
+    @Test
+    void test_non_standard_validation() {
+        Optional<LuxembourgNationalHealthIdValidator.FailureCause> validWithCause = LuxembourgNationalHealthIdValidator.isValidWithCause("4005021384333", 2005, 2, 13);
 
-		System.out.println("validWithCause = " + validWithCause);
-		Assertions.assertTrue(validWithCause.isEmpty());
-	}
+        Assertions.assertTrue(validWithCause.isEmpty());
+    }
 
-	@Test
-	void test_without_birthdate() {
-		Optional<LuxembourgNationalHealthIdValidator.FailureCause> validWithCause = LuxembourgNationalHealthIdValidator.isValidWithCause("3980010145721");
+    @Test
+    void test_non_standard_validation_wrong_birthdate() {
+        Assertions.assertAll(
+                // year
+                () -> assertEquals(LuxembourgNationalHealthIdValidator.FailureCause.BIRTHDATE, LuxembourgNationalHealthIdValidator.isValidWithCause("4005021384333", 2004, 2, 13).orElseThrow()),
+                // month
+                () -> assertEquals(LuxembourgNationalHealthIdValidator.FailureCause.BIRTHDATE, LuxembourgNationalHealthIdValidator.isValidWithCause("4005021384333", 2005, 9, 13).orElseThrow()),
+                // day
+                () -> assertEquals(LuxembourgNationalHealthIdValidator.FailureCause.BIRTHDATE, LuxembourgNationalHealthIdValidator.isValidWithCause("4005021384333", 2005, 2, 20).orElseThrow())
+        );
+    }
 
-		System.out.println("validWithCause = " + validWithCause);
-		Assertions.assertTrue(validWithCause.isEmpty());
-	}
+
+    @Test
+    void test_empty() {
+        assertEquals(LuxembourgNationalHealthIdValidator.FailureCause.EMPTY, LuxembourgNationalHealthIdValidator.isValidWithCause(null).orElseThrow());
+    }
+
+    @Test
+    void test_pattern_missing_check_digit() {
+        assertEquals(LuxembourgNationalHealthIdValidator.FailureCause.PATTERN, LuxembourgNationalHealthIdValidator.isValidWithCause("40050213843").orElseThrow());
+    }
+
+    @Test
+    void test_pattern_empty() {
+        assertEquals(LuxembourgNationalHealthIdValidator.FailureCause.PATTERN, LuxembourgNationalHealthIdValidator.isValidWithCause("").orElseThrow());
+    }
+
+    @Test
+    void test_pattern_unrelated() {
+        assertEquals(LuxembourgNationalHealthIdValidator.FailureCause.PATTERN, LuxembourgNationalHealthIdValidator.isValidWithCause("abcdefghijklm").orElseThrow());
+    }
+
+    @Test
+    void test_without_birthdate() {
+        Optional<LuxembourgNationalHealthIdValidator.FailureCause> validWithCause = LuxembourgNationalHealthIdValidator.isValidWithCause("3934052492435");
+
+        Assertions.assertTrue(validWithCause.isEmpty());
+    }
+
+    @Test
+    void test_check_digit_second_to_last() {
+        // 3 replaced with 1
+        assertEquals(LuxembourgNationalHealthIdValidator.FailureCause.CHECK_DIGITS, LuxembourgNationalHealthIdValidator.isValidWithCause("3934052492415").orElseThrow());
+    }
+
+    @Test
+    void test_check_digit_last() {
+        // 5 replaced with 8
+        assertEquals(LuxembourgNationalHealthIdValidator.FailureCause.CHECK_DIGITS, LuxembourgNationalHealthIdValidator.isValidWithCause("3934052492438").orElseThrow());
+    }
 }


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/sormas-foundation/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #14280 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Luxembourg national health ID validation now provides specific failure reasons, including empty values, invalid patterns, birthdate mismatches, and incorrect check digits.
  - Validation supports IDs beginning with 3 or 4 by correctly interpreting their birth year.
  - Validation can be performed without supplying birthdate details.

- **Bug Fixes**
  - Improved handling of non-standard Luxembourg health IDs and birth year calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->